### PR TITLE
test: add 7 dedicated it blocks for tableToHtml (closes #3)

### DIFF
--- a/src/__tests__/export-html.test.ts
+++ b/src/__tests__/export-html.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import type { DocumentTable } from "../types/table";
 import { tableToHtml } from "../index";
 import { loadFixture } from "./helpers";
 
@@ -17,5 +18,89 @@ describe("tableToHtml", () => {
     const html = tableToHtml(loadFixture("merged-cells-table"));
     expect(html).toContain('rowspan="2"');
     expect(html).toContain('colspan="2"');
+  });
+
+  it("renders rowspan and colspan attributes on merged cells", () => {
+    const html = tableToHtml(loadFixture("merged-cells-table"));
+    expect(html).toContain('rowspan="2"');
+    expect(html).toContain('colspan="2"');
+  });
+
+  it("renders caption as first child of table element", () => {
+    const html = tableToHtml(loadFixture("simple-table"));
+    expect(html).toContain("<table>\n  <caption>Quarterly revenue and margin by region.</caption>");
+  });
+
+  it("places header rows in thead, body rows in tbody, footer rows in tfoot", () => {
+    const html = tableToHtml(loadFixture("footnotes-table"));
+    expect(html).toContain("<thead>");
+    expect(html).toContain("<tbody>");
+    expect(html).toContain("<tfoot>");
+    const theadIndex = html.indexOf("<thead>");
+    const tbodyIndex = html.indexOf("<tbody>");
+    const tfootIndex = html.indexOf("<tfoot>");
+    expect(theadIndex).toBeLessThan(tbodyIndex);
+    expect(tbodyIndex).toBeLessThan(tfootIndex);
+  });
+
+  it("renders footnotes in a div outside the table element", () => {
+    const html = tableToHtml(loadFixture("footnotes-table"));
+    const tableEnd = html.indexOf("</table>");
+    const footnotesDiv = html.indexOf('class="tpds-footnotes"');
+    expect(tableEnd).toBeGreaterThan(-1);
+    expect(footnotesDiv).toBeGreaterThan(tableEnd);
+    expect(html).toContain("¹ Adjusted for age and sex.");
+  });
+
+  it("renders notes in a div outside the table element", () => {
+    const html = tableToHtml(loadFixture("footnotes-table"));
+    const tableEnd = html.indexOf("</table>");
+    const notesDiv = html.indexOf('class="tpds-notes"');
+    expect(tableEnd).toBeGreaterThan(-1);
+    expect(notesDiv).toBeGreaterThan(tableEnd);
+    expect(html).toContain("All values are mean");
+  });
+
+  it("produces valid table markup for a table with no rows or cells", () => {
+    const emptyTable: DocumentTable = {
+      standardVersion: "1.0",
+      tableId: "empty",
+      pages: [],
+      columns: [],
+      rows: [],
+      cells: [],
+    };
+    const html = tableToHtml(emptyTable);
+    expect(html).toContain("<table>");
+    expect(html).toContain("</table>");
+    expect(html).not.toContain("<thead>");
+    expect(html).not.toContain("<tbody>");
+    expect(html).not.toContain("<tfoot>");
+  });
+
+  it("renders isHeader:true body cells as th and non-header body cells as td", () => {
+    const table: DocumentTable = {
+      standardVersion: "1.0",
+      tableId: "mixed-header",
+      pages: [1],
+      columns: [],
+      rows: [
+        { rowIndex: 0, rowType: "header", cellIds: ["h0"] },
+        { rowIndex: 1, rowType: "body", cellIds: ["b0", "b1"] },
+      ],
+      cells: [
+        { cellId: "h0", rowIndex: 0, colIndex: 0, textRaw: "Name", textNormalized: "Name", isHeader: true },
+        { cellId: "b0", rowIndex: 1, colIndex: 0, textRaw: "Alice", textNormalized: "Alice", isHeader: true },
+        { cellId: "b1", rowIndex: 1, colIndex: 1, textRaw: "30", textNormalized: "30" },
+      ],
+    };
+    const html = tableToHtml(table);
+    const tbodyStart = html.indexOf("<tbody>");
+    const tbodyEnd = html.indexOf("</tbody>");
+    const tbodyContent = html.slice(tbodyStart, tbodyEnd);
+    expect(tbodyContent).toContain("<th");
+    expect(tbodyContent).toContain(">Alice<");
+    expect(tbodyContent).toContain("<td");
+    expect(tbodyContent).toContain(">30<");
   });
 });


### PR DESCRIPTION
Closes #3

## Summary

- Adds 7 dedicated `it` blocks to `src/__tests__/export-html.test.ts`
- Uses `merged-cells-table.json`, `simple-table.json`, and `footnotes-table.json` fixtures where applicable
- Inline `DocumentTable` objects for empty-table and `isHeader:true` body-cell cases (no fixture covers these)

## Cases covered

1. `rowspan`/`colspan` attributes — `merged-cells-table.json`
2. `<caption>` as first child of `<table>` — `simple-table.json`
3. `<thead>`/`<tbody>`/`<tfoot>` order — `footnotes-table.json`
4. Footnotes `<div>` appears after `</table>` — `footnotes-table.json`
5. Notes `<div>` appears after `</table>` — `footnotes-table.json`
6. Empty table (no rows/cells) produces valid markup without throwing — inline object
7. `isHeader:true` body cells render as `<th>`, others as `<td>` — inline object

## Test plan

- [x] `npm test` — 25/25 pass, no regressions
- [x] `npm run lint` — clean