### PR TITLE
test: add 6 dedicated it blocks for tableToMarkdown edge cases (closes #4)

### DIFF
--- a/src/__tests__/export-markdown.test.ts
+++ b/src/__tests__/export-markdown.test.ts
@@ -1,19 +1,67 @@
 import { describe, expect, it } from "vitest";
 
 import { tableToMarkdown } from "../index";
+import type { DocumentTable } from "../types/table";
 import { loadFixture } from "./helpers";
 
 describe("tableToMarkdown", () => {
-  it("emits pipe-table markdown for simple tables", () => {
-    const markdown = tableToMarkdown(loadFixture("simple-table"));
-    expect(markdown.fidelity).toBe("lossless");
-    expect(markdown.markdown).toContain("| Quarter | Region | Revenue | Operating Margin |");
+  it("emits pipe-table header row for simple table", () => {
+    const result = tableToMarkdown(loadFixture("simple-table"));
+    expect(result.fidelity).toBe("lossless");
+    expect(result.markdown).toMatch(/\| Quarter \|/);
+    expect(result.markdown).toMatch(/\|[\s-]+\|/);
   });
 
-  it("falls back for merged or complex headers", () => {
-    const markdown = tableToMarkdown(loadFixture("broken-markdown-case"));
-    expect(markdown.fidelity).toBe("lossy");
-    expect(markdown.warnings).toContain("markdown-lossy-fallback");
-    expect(markdown.markdown).toContain("Table: Clinical Trial Outcomes");
+  it("reports lossy fidelity for merged-cell tables", () => {
+    const result = tableToMarkdown(loadFixture("merged-cells-table"));
+    expect(result.fidelity).toBe("lossy");
+    expect(result.warnings).toContain("markdown-lossy-fallback");
+  });
+
+  it("falls back to structured text for wide tables (10+ cols)", () => {
+    const result = tableToMarkdown(loadFixture("wide-table"));
+    expect(result.fidelity).toBe("lossy");
+    expect(result.markdown).not.toMatch(/\|[-\s]+\|/);
+  });
+
+  it("reports lossy and emits no pipe-table separator for broken-markdown-case", () => {
+    const result = tableToMarkdown(loadFixture("broken-markdown-case"));
+    expect(result.fidelity).toBe("lossy");
+    expect(result.markdown).not.toMatch(/\|---/);
+    expect(result.markdown).toContain("Clinical Trial Outcomes");
+  });
+
+  it("produces valid markdown for body-only tables without throwing", () => {
+    const bodyOnly: DocumentTable = {
+      standardVersion: "1.0.0",
+      tableId: "body-only-test",
+      pages: [1],
+      columns: [
+        { colIndex: 0, label: "Name" },
+        { colIndex: 1, label: "Value" },
+      ],
+      rows: [
+        { rowIndex: 0, rowType: "body", cellIds: ["c0", "c1"], page: 1 },
+        { rowIndex: 1, rowType: "body", cellIds: ["c2", "c3"], page: 1 },
+      ],
+      cells: [
+        { cellId: "c0", rowIndex: 0, colIndex: 0, textRaw: "Alpha", textNormalized: "Alpha", page: 1 },
+        { cellId: "c1", rowIndex: 0, colIndex: 1, textRaw: "1", textNormalized: "1", page: 1 },
+        { cellId: "c2", rowIndex: 1, colIndex: 0, textRaw: "Beta", textNormalized: "Beta", page: 1 },
+        { cellId: "c3", rowIndex: 1, colIndex: 1, textRaw: "2", textNormalized: "2", page: 1 },
+      ],
+    };
+    let result: ReturnType<typeof tableToMarkdown> | undefined;
+    expect(() => {
+      result = tableToMarkdown(bodyOnly);
+    }).not.toThrow();
+    expect(typeof result?.markdown).toBe("string");
+  });
+
+  it("appends footnotes below pipe-table body", () => {
+    const result = tableToMarkdown(loadFixture("footnotes-table"));
+    expect(result.fidelity).toBe("lossless");
+    expect(result.markdown).toContain("Adjusted for age and sex");
+    expect(result.markdown).toContain("Excludes outliers beyond 3 SD");
   });
 });

--- a/src/export/to-markdown.ts
+++ b/src/export/to-markdown.ts
@@ -21,6 +21,10 @@ const isSimpleMarkdownTable = (table: DocumentTable): boolean => {
     return false;
   }
 
+  if (maxColumnIndex(table) + 1 >= 10) {
+    return false;
+  }
+
   const headerRows = table.rows.filter((row) => row.rowType === "header" && !row.repeatedHeaderRow);
   return headerRows.length <= 1;
 };
@@ -106,6 +110,11 @@ export const tableToMarkdown = (table: DocumentTable): MarkdownExportResult => {
   lines.push(`| ${headerValues.join(" | ")} |`);
   lines.push(`| ${headerValues.map(() => "---").join(" | ")} |`);
   lines.push(...bodyValues.map((row) => `| ${row.join(" | ")} |`));
+
+  if (table.footnotes && table.footnotes.length > 0) {
+    lines.push("");
+    lines.push(...table.footnotes.map((f) => `_${f}_`));
+  }
 
   return {
     markdown: lines.join("\n"),


### PR DESCRIPTION
## Summary

- Adds 6 dedicated `it` blocks to `src/__tests__/export-markdown.test.ts`
- Adds ≥10-column check to `isSimpleMarkdownTable` so wide tables fall back to structured text
- Appends footnotes below the pipe-table body in the lossless path

## Changes

### `src/export/to-markdown.ts`
- `isSimpleMarkdownTable`: returns `false` when table has ≥10 columns
- Pipe-table path: appends `_footnote_` lines after body rows when `table.footnotes` is non-empty

### `src/__tests__/export-markdown.test.ts`
| # | Case | Fixture | Key assertion |
|---|------|---------|---------------|
| 1 | Simple round-trip | `simple-table` | pipe-table header row present, `fidelity === "lossless"` |
| 2 | Merged cells | `merged-cells-table` | `fidelity === "lossy"` |
| 3 | Wide table (11 cols) | `wide-table` | `fidelity === "lossy"`, no `|---|` separator |
| 4 | Broken markdown case | `broken-markdown-case` | `fidelity === "lossy"`, no `|---` |
| 5 | Body-only table | inline fixture | no throw, markdown is string |
| 6 | Footnotes appended | `footnotes-table` | footnote text present in output |

## Test plan

- [x] `npm test` passes (29/29, no regressions)
- [x] `isLossy` asserted via `fidelity === "lossy"` wherever lossiness is expected
- [x] No test asserts exact markdown string — structural properties only

Closes #4  