### PR TITLE
ci: add npm publish workflow triggered on v*.*.* tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm test
+
+      - run: npm run build
+
+      - run: npm run smoke
+
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -123,4 +123,20 @@ npm install
 npm run lint
 npm test
 npm run build
+npm run smoke   # smoke-test ESM + CJS output against dist/
 ```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full versioning policy and workflow.
+
+### Publishing
+
+Releases are published automatically when a `v*.*.*` tag is pushed. The
+`.github/workflows/publish.yml` workflow runs lint, tests, build, and smoke
+tests before calling `npm publish`.
+
+To authorize the workflow you must add an **`NPM_TOKEN`** secret to the
+repository (`Settings → Secrets and variables → Actions → New repository
+secret`). Generate the token at npmjs.com under `Access Tokens → Granular
+Access Token` with **Read and Write** permission for this package.


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish.yml` that triggers **only on `v*.*.*` tag pushes** — never on branch pushes or PRs. The workflow runs lint → test → build → smoke → `npm publish`. Documents the required `NPM_TOKEN` repository secret in `README.md`.

## Changes

- `.github/workflows/publish.yml` — new publish workflow (tag-only trigger, `NODE_AUTH_TOKEN` from `NPM_TOKEN` secret)
- `README.md` — added Contributing section documenting `NPM_TOKEN` setup and the publish workflow

## Closes

Closes #7