### PR TITLE
test: add ESM and CJS consumer smoke tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "build": "tsup",
     "clean": "rm -rf dist",
     "lint": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "smoke": "node test/smoke/esm.mjs && node test/smoke/cjs.cjs"
   },
   "keywords": [
     "tables",

--- a/test/smoke/cjs.cjs
+++ b/test/smoke/cjs.cjs
@@ -1,0 +1,27 @@
+"use strict";
+
+const { normalizeTable, safeValidateTable, buildTableChunks } = require("../../dist/index.cjs");
+
+const raw = {
+  tableId: "smoke-t2",
+  title: "Smoke CJS",
+  pages: [1],
+  rows: [
+    { rowIndex: 0, rowType: "header", cellIds: ["smoke-t2:0:0"] },
+    { rowIndex: 1, rowType: "body", cellIds: ["smoke-t2:1:0"] },
+  ],
+  columns: [{ colIndex: 0, header: "Col" }],
+  cells: [
+    { cellId: "smoke-t2:0:0", rowIndex: 0, colIndex: 0, textRaw: "Col", textNormalized: "Col", isHeader: true },
+    { cellId: "smoke-t2:1:0", rowIndex: 1, colIndex: 0, textRaw: "Val", textNormalized: "Val", isHeader: false },
+  ],
+};
+
+const table = normalizeTable(raw);
+const valid = safeValidateTable(table);
+if (!valid.success) throw new Error("safeValidateTable failed: " + JSON.stringify(valid.error));
+
+const chunks = buildTableChunks(table);
+if (!Array.isArray(chunks) || chunks.length === 0) throw new Error("buildTableChunks returned empty");
+
+console.log("CJS smoke OK — chunks:", chunks.length);

--- a/test/smoke/esm.mjs
+++ b/test/smoke/esm.mjs
@@ -1,0 +1,25 @@
+import { normalizeTable, safeValidateTable, buildTableChunks } from "../../dist/index.js";
+
+const raw = {
+  tableId: "smoke-t1",
+  title: "Smoke ESM",
+  pages: [1],
+  rows: [
+    { rowIndex: 0, rowType: "header", cellIds: ["smoke-t1:0:0"] },
+    { rowIndex: 1, rowType: "body", cellIds: ["smoke-t1:1:0"] },
+  ],
+  columns: [{ colIndex: 0, header: "Col" }],
+  cells: [
+    { cellId: "smoke-t1:0:0", rowIndex: 0, colIndex: 0, textRaw: "Col", textNormalized: "Col", isHeader: true },
+    { cellId: "smoke-t1:1:0", rowIndex: 1, colIndex: 0, textRaw: "Val", textNormalized: "Val", isHeader: false },
+  ],
+};
+
+const table = normalizeTable(raw);
+const valid = safeValidateTable(table);
+if (!valid.success) throw new Error("safeValidateTable failed: " + JSON.stringify(valid.error));
+
+const chunks = buildTableChunks(table);
+if (!Array.isArray(chunks) || chunks.length === 0) throw new Error("buildTableChunks returned empty");
+
+console.log("ESM smoke OK — chunks:", chunks.length);


### PR DESCRIPTION
## Summary

Adds `test/smoke/esm.mjs` and `test/smoke/cjs.cjs` that import directly from `dist/` and exercise `normalizeTable`, `safeValidateTable`, and `buildTableChunks` with a minimal fixture. Adds `"smoke"` script to `package.json`. The `test/smoke/` directory is already excluded from the npm package via the existing `files` field.

## Changes

- `test/smoke/esm.mjs` — ESM smoke test using `dist/index.js`
- `test/smoke/cjs.cjs` — CJS smoke test using `dist/index.cjs`
- `package.json` — added `"smoke": "node test/smoke/esm.mjs && node test/smoke/cjs.cjs"` script

## Closes

Closes #8