### PR TITLE
docs: add CHANGELOG.md and versioning policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,73 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- **Zod schema** (`src/schema/zod.ts`): canonical `documentTableSchema` with
+  `TableCell`, `TableRow`, `TableColumn`, `TableContinuity`, and `DocumentTable`
+  shapes. `tableChunkSchema` and discriminated union for all chunk types.
+- **TypeScript types** (`src/types/`): `DocumentTable`, `TableCell`, `TableRow`,
+  `TableColumn`, `TableContinuity`, `TableChunk`, and related types inferred
+  from or mirrored against the Zod schemas.
+- **`normalizeTable`** (`src/normalize/normalize-table.ts`): two-phase
+  normalization — hand-written guard helpers coerce messy/unknown input, then
+  `documentTableSchema.parse()` validates the result. Assigns stable `cellId`s
+  in `{tableId}:{rowIndex}:{colIndex}` format.
+- **`inferHeaders`** (`src/normalize/infer-headers.ts`): heuristic header
+  inference for tables where no explicit header row is marked.
+- **`mergeMultiPageTables`** (`src/normalize/merge-multipage.ts`): groups tables
+  by `continuity.logicalTableGroupId` → title+columns → `tableId` fallback,
+  offsets row and cell indexes of continuation pages, and merges rows/cells into
+  a single `DocumentTable`.
+- **`buildTableChunks`** (`src/chunk/build-table-chunks.ts`): orchestrates all
+  chunk builders and returns a flat array of typed chunks.
+- **`buildSummaryChunk`** (`src/chunk/build-summary-chunk.ts`): produces a
+  `summary` chunk with table-level metadata.
+- **`buildRowChunks`** / **row-group chunking** (`src/chunk/build-row-chunks.ts`):
+  produces one `row` chunk per body row or batched `row-group` chunks. Detects
+  and skips repeated continuation headers by default.
+- **`buildNoteChunks`** (`src/chunk/build-note-chunks.ts`): produces `notes`
+  chunks from any annotated note rows.
+- **`tableToHtml`** (`src/export/to-html.ts`): renders a `DocumentTable` to an
+  HTML `<table>` string preserving header rows and merged-cell intent.
+- **`tableToMarkdown`** (`src/export/to-markdown.ts`): best-effort Markdown
+  table export; lossy for merged cells.
+- **`tableToJson`** (`src/export/to-json.ts`): serialises a `DocumentTable` to
+  a plain JSON-serialisable object.
+- **Utility helpers** (`src/utils/`): `guards.ts` (type-guard helpers used by
+  normalizeTable), `ids.ts` (cellId helpers), `text.ts` (text normalisation),
+  `table.ts` (column sorting helpers).
+- **Public barrel** (`src/index.ts`): single entry point re-exporting all
+  public API symbols.
+- **Dual ESM + CJS build** via `tsup`; `.d.ts` declarations included.
+
+### Changed
+
+- Nothing yet — initial release.
+
+### Deprecated
+
+- Nothing yet.
+
+### Removed
+
+- Nothing yet.
+
+### Fixed
+
+- Nothing yet.
+
+### Security
+
+- Nothing yet.
+
+[Unreleased]: https://github.com/boilerrat/TPDS/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/boilerrat/TPDS/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing
+
+## Development Setup
+
+```bash
+git clone https://github.com/boilerrat/TPDS.git
+cd TPDS
+npm install
+npm run lint
+npm test
+npm run build
+npm run smoke   # verify ESM + CJS output
+```
+
+## Pull Requests
+
+- Branch from `main`.
+- All PRs must close a GitHub issue (`Closes #N` in body — enforced by CI).
+- Run `npm run lint && npm test && npm run build` before opening a PR.
+- Fill out every section of the PR template.
+
+## Versioning Policy
+
+This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The **npm package version** (`package.json`) and the **schema version** tracked
+in `CHANGELOG.md` are kept in sync.
+
+| Change type | npm package | Schema note |
+|---|---|---|
+| Breaking schema change (renamed/removed fields, stricter validation) | **major** bump | major entry in CHANGELOG |
+| Additive schema change (new optional fields, new chunk types) | **minor** bump | minor entry in CHANGELOG |
+| Bug fix, non-schema logic change, documentation, tooling | **patch** bump | patch entry in CHANGELOG |
+
+### Bumping the version
+
+```bash
+# patch
+npm version patch
+
+# minor
+npm version minor
+
+# major
+npm version major
+```
+
+`npm version` updates `package.json`, creates a commit, and tags it. Pushing
+the tag triggers the publish workflow:
+
+```bash
+git push origin main --follow-tags
+```
+
+### Changelog
+
+Update `CHANGELOG.md` before every release using the
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format:
+
+1. Add entries under `## [Unreleased]` as you develop.
+2. Before releasing, rename `[Unreleased]` to the new version with today's date.
+3. Add a fresh empty `## [Unreleased]` section at the top.
+
+## Publishing
+
+Releases publish automatically when a `v*.*.*` tag is pushed (see
+`.github/workflows/publish.yml`). The workflow requires an **`NPM_TOKEN`**
+repository secret — see [README.md](README.md#publishing) for setup
+instructions.


### PR DESCRIPTION
## Summary

Adds `CHANGELOG.md` in Keep a Changelog format with a full `[0.1.0]` entry covering all features shipped in Phase 1 (schema, normalize, chunk, export, merge, utils). Adds `CONTRIBUTING.md` with the semver versioning policy: major for breaking schema changes, minor for additive schema changes, patch for everything else.

## Changes

- `CHANGELOG.md` — initial changelog with `[0.1.0] - Unreleased` entry documenting all Phase 1 additions
- `CONTRIBUTING.md` — dev setup, PR workflow, versioning policy table, bump instructions, changelog update process

## Closes

Closes #9