### PR TITLE
docs: audit public API surface and finalize index.ts exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,22 +90,77 @@ console.log(merged.length);
 
 ## Public API
 
+### Functions
+
 ```ts
 import {
-  buildNoteChunks,
-  buildRowChunks,
-  buildSummaryChunk,
-  buildTableChunks,
-  documentTableSchema,
-  inferHeaders,
-  mergeMultiPageTables,
-  normalizeTable,
-  safeValidateTable,
+  // normalization
+  normalizeTable,       // (input: unknown, opts?: NormalizeTableOptions) => DocumentTable
+  inferHeaders,         // (table: DocumentTable) => DocumentTable
+  mergeMultiPageTables, // (tables: DocumentTable[], opts?: MergeMultiPageTablesOptions) => DocumentTable[]
+  // validation
+  validateTable,        // (input: unknown) => DocumentTable  (throws on failure)
+  safeValidateTable,    // (input: unknown) => { success: boolean; data?: DocumentTable; error?: ZodError }
+  // export
+  tableToHtml,          // (table: DocumentTable) => string
+  tableToMarkdown,      // (table: DocumentTable) => MarkdownExportResult
+  tableToJson,          // (table: DocumentTable) => JsonRecord
+  // chunking
+  buildTableChunks,     // (table: DocumentTable, opts?: BuildTableChunksOptions) => TableChunk[]
+  buildRowChunks,       // (table: DocumentTable, opts?: BuildRowChunksOptions) => TableChunk[]
+  buildRowGroupChunks,  // (table: DocumentTable, groupSize: number, opts?: BuildRowChunksOptions) => TableChunk[]
+  buildSummaryChunk,    // (table: DocumentTable) => TableChunk
+  buildNoteChunks,      // (table: DocumentTable) => TableChunk[]
+} from "table-preserving-doc-standard";
+```
+
+### Schemas (Zod)
+
+```ts
+import {
+  documentTableSchema,  // root schema — use with .parse() / .safeParse()
+  tableCellSchema,
+  tableRowSchema,
+  tableColumnSchema,
   tableChunkSchema,
-  tableToHtml,
-  tableToJson,
-  tableToMarkdown,
-  validateTable
+  headerGroupSchema,
+  pageSpanSchema,
+  continuitySchema,
+  provenanceSchema,
+  sourceRefSchema,
+  boundingBoxSchema,
+} from "table-preserving-doc-standard";
+```
+
+### Types
+
+```ts
+import type {
+  // core model
+  DocumentTable,
+  TableCell,
+  TableRow,
+  TableColumn,
+  TableContinuity,
+  HeaderGroup,
+  PageSpan,
+  // chunks
+  TableChunk,
+  TableChunkType,
+  BuildTableChunksOptions,
+  BuildRowChunksOptions,
+  MarkdownExportResult,
+  // shared primitives
+  BoundingBox,
+  CoordinateSpace,
+  JsonRecord,
+  Provenance,
+  RowType,
+  SourceRef,
+  ValueType,
+  // option bags
+  NormalizeTableOptions,
+  MergeMultiPageTablesOptions,
 } from "table-preserving-doc-standard";
 ```
 


### PR DESCRIPTION
## Summary

- Audited every export in `src/index.ts` — all belong in the public API; no internal utilities leaked
- `src/utils/` functions (`guards`, `ids`, `text`, `table`) confirmed not re-exported
- `package.json` `exports`/`main`/`module`/`types` fields verified correct for dual ESM+CJS build
- Expanded README Public API section into three sub-sections: **Functions**, **Schemas (Zod)**, and **Types**

## Changes

- `README.md` — adds `buildRowGroupChunks`, 9 missing Zod sub-schemas, and 21 TypeScript type exports to the Public API section; restructures into Functions / Schemas / Types blocks

## Verification

- `npm pack --dry-run` lists only `dist/` files, `README.md`, and `package.json` (npm always includes `package.json`)
- `npm run lint` — clean
- `npm test` — 46 tests pass
- `npm run build` — ESM + CJS + `.d.ts` emitted cleanly

## Closes

Closes #10