### PR TITLE
docs: expand CONTRIBUTING with branch naming, CI, fixtures, schema rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,3 +66,81 @@ Releases publish automatically when a `v*.*.*` tag is pushed (see
 `.github/workflows/publish.yml`). The workflow requires an **`NPM_TOKEN`**
 repository secret — see [README.md](README.md#publishing) for setup
 instructions.
+
+---
+
+## Branch Naming
+
+Branch names follow the pattern `issue-N-short-description`:
+
+```
+issue-11-schema-docs
+issue-14-readme-expand
+```
+
+Always branch from `main`. One branch per issue.
+
+---
+
+## CI Checks Required Before Merge
+
+The following checks are enforced by CI (`.github/workflows/ci.yml`) on every push and pull request to `main`. All must pass before a PR can merge:
+
+1. **Type check** — `npm run lint` (runs `tsc --noEmit`)
+2. **Tests** — `npm test` (runs all Vitest tests)
+3. **Build** — `npm run build` (produces `dist/`)
+4. **PR issue link** — enforced by `.github/workflows/pr-issue-check.yml`; the PR body must contain `Closes #N`, `Fixes #N`, or `Resolves #N`
+
+Run all checks locally before opening a PR:
+
+```bash
+npm run lint && npm test && npm run build
+```
+
+---
+
+## Code Review
+
+Every PR to `main` requires **1 approving review** before it can be merged. Fill out every section of [`.github/pull_request_template.md`](.github/pull_request_template.md) — the `## Closes` section must contain a linked issue.
+
+For bug and feature issue templates see [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/).
+
+---
+
+## Running a Single Test File
+
+```bash
+npx vitest run src/__tests__/<filename>.test.ts
+```
+
+Example:
+
+```bash
+npx vitest run src/__tests__/chunking.test.ts
+```
+
+All test files live in `src/__tests__/` and match `**/*.test.ts`.
+
+---
+
+## Fixture Conventions
+
+Fixtures are JSON files in `src/fixtures/`. They are the canonical source of
+test inputs for normalization, export, and chunking.
+
+Rules for every fixture:
+
+1. **Must pass `validateTable`** — the fixture must be a valid `DocumentTable`. If you need to test invalid input, construct it inline in the test file instead.
+2. **Named for the edge case it covers** — the filename should describe what the fixture tests, e.g. `merged-cells-table.json`, `repeated-headers-table.json`.
+3. **Referenced in a test** — every fixture must be imported and exercised in at least one test in `src/__tests__/`.
+
+---
+
+## Schema Change Rules
+
+When adding or modifying fields in the schema:
+
+1. **Update both `src/schema/zod.ts` and `src/types/`** — the Zod schema and the mirrored TypeScript types must stay in sync. When they diverge, Zod wins at runtime.
+2. **Optional-only for minor and patch releases** — new fields added in a minor or patch release must be optional (`z.optional()` in Zod, `?` in TypeScript types). Adding a required field is a breaking change.
+3. **Required fields require a major bump** — if a new field must be required, bump `standardVersion` and the npm package major version before merging.
+4. **Update `standardVersion` in `package.json`** — the `standardVersion` constant should match the npm package version you are targeting for the release.


### PR DESCRIPTION
## Summary

Expands `CONTRIBUTING.md` by appending five new sections without touching the existing content. Covers the gaps identified in issue #13.

## Changes

- **Branch Naming** — `issue-N-short-description` convention
- **CI Checks Required Before Merge** — lint, test, build, and PR issue link enforced by CI; links to workflow files
- **Code Review** — 1 approving review required; links to PR template and issue templates
- **Running a Single Test File** — `npx vitest run src/__tests__/<file>.test.ts`
- **Fixture Conventions** — must pass `validateTable`, named for edge case, referenced in a test
- **Schema Change Rules** — update both `zod.ts` and `src/types/`, optional-only for minor/patch, required fields = major bump

## Closes

Closes #13