### PR TITLE
docs: motivation section, full API reference table, chunking example, links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 `table-preserving-doc-standard` provides a canonical JSON table model for document ingestion workflows. It validates, normalizes, exports, and chunks extracted tables without treating Markdown as the source of truth.
 
+## Motivation
+
+Document ingestion pipelines still break on tables. PDFs store visual layout, not semantic intent. When extraction tools flatten a table into plain text or weak Markdown, meaning gets damaged: rows lose their headers, merged cells lose structure, multi-page tables split into fragments, and footnotes detach from values. The result is that retrieval quality drops, answers get worse, and trust drops. Every RAG pipeline, compliance workflow, and document-aware AI system that processes PDFs inherits this damage if nothing in the pipeline preserves the table as a structured object.
+
+This project defines a stable intermediate layer between extraction and retrieval. Upstream systems detect and extract. Downstream systems chunk, embed, index, and answer. `table-preserving-doc-standard` sits in the middle and preserves the table as a logical object with explicit relationships between headers, cells, rows, columns, notes, units, and source context. Markdown is treated as a derivative — useful for human inspection, not authoritative for complex tables with merged cells, nested headers, or page-spanning continuity. JSON is canonical. The schema is retrieval-aware from the start.
+
 ## What it covers
 
 - canonical TypeScript and Zod schema
@@ -88,49 +94,55 @@ const merged = mergeMultiPageTables([table]);
 console.log(merged.length);
 ```
 
-## Public API
+## Chunking output
+
+`buildTableChunks` returns one chunk per body row (plus a summary chunk). Each row chunk carries enough context for standalone retrieval. For the table above, the row chunk for row 1 looks like:
+
+```
+Table: Revenue by Quarter
+Section: Financial Results > Q1 2025
+Page Range: 14-15
+Quarter: Q1 2025
+Revenue: 12.4M
+```
+
+The `chunkType` is `"row"`, `rowIndexes` is `[1]`, and `tokenEstimate` counts the tokens in that text. The summary chunk captures the table-level context (title, columns, page range) without any row data.
+
+## API Reference
 
 ### Functions
 
-```ts
-import {
-  // normalization
-  normalizeTable,       // (input: unknown, opts?: NormalizeTableOptions) => DocumentTable
-  inferHeaders,         // (table: DocumentTable) => DocumentTable
-  mergeMultiPageTables, // (tables: DocumentTable[], opts?: MergeMultiPageTablesOptions) => DocumentTable[]
-  // validation
-  validateTable,        // (input: unknown) => DocumentTable  (throws on failure)
-  safeValidateTable,    // (input: unknown) => { success: boolean; data?: DocumentTable; error?: ZodError }
-  // export
-  tableToHtml,          // (table: DocumentTable) => string
-  tableToMarkdown,      // (table: DocumentTable) => MarkdownExportResult
-  tableToJson,          // (table: DocumentTable) => JsonRecord
-  // chunking
-  buildTableChunks,     // (table: DocumentTable, opts?: BuildTableChunksOptions) => TableChunk[]
-  buildRowChunks,       // (table: DocumentTable, opts?: BuildRowChunksOptions) => TableChunk[]
-  buildRowGroupChunks,  // (table: DocumentTable, groupSize: number, opts?: BuildRowChunksOptions) => TableChunk[]
-  buildSummaryChunk,    // (table: DocumentTable) => TableChunk
-  buildNoteChunks,      // (table: DocumentTable) => TableChunk[]
-} from "table-preserving-doc-standard";
-```
+| Export | Signature | Description |
+|--------|-----------|-------------|
+| `normalizeTable` | `(input: unknown, opts?: NormalizeTableOptions) => DocumentTable` | Accepts raw/messy input, coerces fields defensively, and validates against the Zod schema |
+| `inferHeaders` | `(table: DocumentTable) => DocumentTable` | Populates `inferredHeaders` on body cells by walking up the header rows |
+| `mergeMultiPageTables` | `(tables: DocumentTable[], opts?: MergeMultiPageTablesOptions) => DocumentTable[]` | Groups fragments by `logicalTableGroupId` and merges them into one table per logical group |
+| `validateTable` | `(input: unknown) => DocumentTable` | Validates input with `documentTableSchema.parse()`; throws `ZodError` on failure |
+| `safeValidateTable` | `(input: unknown) => SafeParseReturnType<DocumentTable>` | Validates without throwing; returns `{ success, data, error }` |
+| `tableToHtml` | `(table: DocumentTable) => string` | Exports as a `<table>` HTML string with `colspan`/`rowspan` attributes |
+| `tableToMarkdown` | `(table: DocumentTable) => MarkdownExportResult` | Exports as pipe-table Markdown; `fidelity` is `"lossy"` when merged cells are present |
+| `tableToJson` | `(table: DocumentTable) => JsonRecord` | Exports as a plain `Record<string, unknown>` |
+| `buildTableChunks` | `(table: DocumentTable, opts?: BuildTableChunksOptions) => TableChunk[]` | Builds all chunk types in one call (summary + row/row-group + notes) |
+| `buildRowChunks` | `(table: DocumentTable, opts?: BuildRowChunksOptions) => TableChunk[]` | Builds one `"row"` chunk per body row |
+| `buildRowGroupChunks` | `(table: DocumentTable, groupSize: number, opts?: BuildRowChunksOptions) => TableChunk[]` | Batches N consecutive body rows into `"row-group"` chunks |
+| `buildSummaryChunk` | `(table: DocumentTable) => TableChunk` | Builds a single `"summary"` chunk with title, section, page range, and column names |
+| `buildNoteChunks` | `(table: DocumentTable) => TableChunk[]` | Builds `"notes"` chunks from `notes` and `footnotes` arrays |
 
 ### Schemas (Zod)
 
-```ts
-import {
-  documentTableSchema,  // root schema — use with .parse() / .safeParse()
-  tableCellSchema,
-  tableRowSchema,
-  tableColumnSchema,
-  tableChunkSchema,
-  headerGroupSchema,
-  pageSpanSchema,
-  continuitySchema,
-  provenanceSchema,
-  sourceRefSchema,
-  boundingBoxSchema,
-} from "table-preserving-doc-standard";
-```
+| Export | Description |
+|--------|-------------|
+| `documentTableSchema` | Root schema — use with `.parse()` / `.safeParse()` |
+| `tableCellSchema` | Schema for `TableCell` |
+| `tableRowSchema` | Schema for `TableRow` |
+| `tableColumnSchema` | Schema for `TableColumn` |
+| `tableChunkSchema` | Schema for `TableChunk` |
+| `headerGroupSchema` | Schema for `HeaderGroup` |
+| `pageSpanSchema` | Schema for `PageSpan` |
+| `continuitySchema` | Schema for `TableContinuity` |
+| `provenanceSchema` | Schema for `Provenance` |
+| `sourceRefSchema` | Schema for `SourceRef` |
+| `boundingBoxSchema` | Schema for `BoundingBox` |
 
 ### Types
 
@@ -195,3 +207,9 @@ To authorize the workflow you must add an **`NPM_TOKEN`** secret to the
 repository (`Settings → Secrets and variables → Actions → New repository
 secret`). Generate the token at npmjs.com under `Access Tokens → Granular
 Access Token` with **Read and Write** permission for this package.
+
+## Links
+
+- [Schema reference](docs/schema.md) — field-level documentation for every type
+- [Examples](docs/examples.md) — runnable TypeScript examples for normalize, merge, and export
+- [Contributing](CONTRIBUTING.md) — branch naming, CI checks, fixture conventions, schema change rules


### PR DESCRIPTION
## Summary

Expands `README.md` with four additions while preserving all existing content: a motivation section pulled from `docs/vision.md`, a scannable API reference table covering every exported symbol, a chunking output example showing literal chunk text, and a Links section pointing to the new docs.

## Changes

- **Motivation** (2 paragraphs) — why PDF table ingestion breaks, why Markdown is not enough, what TPDS solves; sourced from `docs/vision.md`
- **Chunking output example** — shows the literal text produced by `buildTableChunks` for a single body row
- **API Reference table** — `| Export | Signature | Description |` for all 13 functions; Zod schema table; Types block preserved
- **Links section** — `docs/schema.md`, `docs/examples.md`, `CONTRIBUTING.md` — all paths verified to resolve from repo root

## Closes

Closes #14