### PR TITLE
feat: add addFidelityWarnings utility (#15)

### DIFF
--- a/src/__tests__/fidelity.test.ts
+++ b/src/__tests__/fidelity.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+
+import { addFidelityWarnings } from "../utils/fidelity-warnings";
+import type { DocumentTable } from "../types/table";
+import { loadFixture } from "./helpers";
+
+const baseTable: DocumentTable = {
+  standardVersion: "1.0.0",
+  tableId: "test-table",
+  pages: [1],
+  columns: [{ colIndex: 0 }, { colIndex: 1 }],
+  rows: [
+    { rowIndex: 0, rowType: "header", cellIds: ["c0", "c1"] },
+    { rowIndex: 1, rowType: "body", cellIds: ["c2", "c3"] }
+  ],
+  cells: [
+    { cellId: "c0", rowIndex: 0, colIndex: 0, textRaw: "Col A", textNormalized: "Col A" },
+    { cellId: "c1", rowIndex: 0, colIndex: 1, textRaw: "Col B", textNormalized: "Col B" },
+    { cellId: "c2", rowIndex: 1, colIndex: 0, textRaw: "val", textNormalized: "val" },
+    { cellId: "c3", rowIndex: 1, colIndex: 1, textRaw: "val2", textNormalized: "val2" }
+  ]
+};
+
+describe("addFidelityWarnings", () => {
+  it("returns new object — does not mutate input", () => {
+    const result = addFidelityWarnings(baseTable);
+    expect(result).not.toBe(baseTable);
+  });
+
+  it("returns no warnings for a clean table", () => {
+    const result = addFidelityWarnings(baseTable);
+    expect(result.fidelityWarnings ?? []).toHaveLength(0);
+  });
+
+  it("detects merged-cells-present via rowSpan > 1", () => {
+    const table: DocumentTable = {
+      ...baseTable,
+      cells: [{ ...baseTable.cells[0]!, rowSpan: 2 }, ...baseTable.cells.slice(1)]
+    };
+    const result = addFidelityWarnings(table);
+    expect(result.fidelityWarnings).toContain("merged-cells-present");
+  });
+
+  it("detects merged-cells-present via colSpan > 1", () => {
+    const table: DocumentTable = {
+      ...baseTable,
+      cells: [{ ...baseTable.cells[0]!, colSpan: 2 }, ...baseTable.cells.slice(1)]
+    };
+    const result = addFidelityWarnings(table);
+    expect(result.fidelityWarnings).toContain("merged-cells-present");
+  });
+
+  it("sets markdown-lossy when merged-cells-present", () => {
+    const table: DocumentTable = {
+      ...baseTable,
+      cells: [{ ...baseTable.cells[0]!, rowSpan: 2 }, ...baseTable.cells.slice(1)]
+    };
+    const result = addFidelityWarnings(table);
+    expect(result.fidelityWarnings).toContain("markdown-lossy");
+  });
+
+  it("does not set markdown-lossy without merged-cells-present", () => {
+    const result = addFidelityWarnings(baseTable);
+    expect(result.fidelityWarnings ?? []).not.toContain("markdown-lossy");
+  });
+
+  it("detects headers-inferred", () => {
+    const table: DocumentTable = {
+      ...baseTable,
+      cells: [
+        { ...baseTable.cells[0]!, inferredHeaders: ["Some Header"] },
+        ...baseTable.cells.slice(1)
+      ]
+    };
+    const result = addFidelityWarnings(table);
+    expect(result.fidelityWarnings).toContain("headers-inferred");
+  });
+
+  it("does not set headers-inferred when inferredHeaders is absent or empty", () => {
+    const result = addFidelityWarnings(baseTable);
+    expect(result.fidelityWarnings ?? []).not.toContain("headers-inferred");
+  });
+
+  it("detects repeated-headers-detected", () => {
+    const table: DocumentTable = {
+      ...baseTable,
+      rows: [
+        ...baseTable.rows,
+        { rowIndex: 2, rowType: "header", cellIds: ["c4", "c5"], repeatedHeaderRow: true }
+      ],
+      cells: [
+        ...baseTable.cells,
+        { cellId: "c4", rowIndex: 2, colIndex: 0, textRaw: "Col A", textNormalized: "Col A" },
+        { cellId: "c5", rowIndex: 2, colIndex: 1, textRaw: "Col B", textNormalized: "Col B" }
+      ]
+    };
+    const result = addFidelityWarnings(table);
+    expect(result.fidelityWarnings).toContain("repeated-headers-detected");
+  });
+
+  it("does not set repeated-headers-detected without repeatedHeaderRow", () => {
+    const result = addFidelityWarnings(baseTable);
+    expect(result.fidelityWarnings ?? []).not.toContain("repeated-headers-detected");
+  });
+
+  it("detects ocr-noise-suspected when edit distance > 1", () => {
+    const table: DocumentTable = {
+      ...baseTable,
+      cells: [
+        ...baseTable.cells.slice(0, 2),
+        { ...baseTable.cells[2]!, textRaw: "l2,450", textNormalized: "12450" },
+        baseTable.cells[3]!
+      ]
+    };
+    const result = addFidelityWarnings(table);
+    expect(result.fidelityWarnings).toContain("ocr-noise-suspected");
+  });
+
+  it("does not set ocr-noise-suspected when edit distance <= 1", () => {
+    const table: DocumentTable = {
+      ...baseTable,
+      cells: [
+        ...baseTable.cells.slice(0, 2),
+        { ...baseTable.cells[2]!, textRaw: "vak", textNormalized: "val" },
+        baseTable.cells[3]!
+      ]
+    };
+    const result = addFidelityWarnings(table);
+    expect(result.fidelityWarnings ?? []).not.toContain("ocr-noise-suspected");
+  });
+
+  it("does not set ocr-noise-suspected when textRaw equals textNormalized", () => {
+    const result = addFidelityWarnings(baseTable);
+    expect(result.fidelityWarnings ?? []).not.toContain("ocr-noise-suspected");
+  });
+
+  it("detects multi-page-merged when continuity.isMultiPage is true", () => {
+    const table: DocumentTable = { ...baseTable, continuity: { isMultiPage: true } };
+    const result = addFidelityWarnings(table);
+    expect(result.fidelityWarnings).toContain("multi-page-merged");
+  });
+
+  it("does not set multi-page-merged when continuity.isMultiPage is false", () => {
+    const table: DocumentTable = { ...baseTable, continuity: { isMultiPage: false } };
+    const result = addFidelityWarnings(table);
+    expect(result.fidelityWarnings ?? []).not.toContain("multi-page-merged");
+  });
+
+  it("does not set multi-page-merged when continuity is absent", () => {
+    const result = addFidelityWarnings(baseTable);
+    expect(result.fidelityWarnings ?? []).not.toContain("multi-page-merged");
+  });
+
+  it("all fixtures pass through without throwing", () => {
+    for (const name of [
+      "simple-table",
+      "merged-cells-table",
+      "multipage-table",
+      "broken-markdown-case",
+      "footnotes-table",
+      "wide-table",
+      "ocr-noisy-table",
+      "repeated-headers-table",
+      "financial-table",
+      "nested-headers-table",
+      "wage-schedule-colspan",
+      "wage-schedule-rowspan"
+    ]) {
+      const fixture = loadFixture(name);
+      expect(() => addFidelityWarnings(fixture)).not.toThrow();
+    }
+  });
+
+  it("ocr-noisy-table fixture triggers ocr-noise-suspected", () => {
+    const fixture = loadFixture("ocr-noisy-table");
+    const result = addFidelityWarnings(fixture);
+    expect(result.fidelityWarnings).toContain("ocr-noise-suspected");
+  });
+
+  it("merged-cells-table fixture triggers merged-cells-present and markdown-lossy", () => {
+    const fixture = loadFixture("merged-cells-table");
+    const result = addFidelityWarnings(fixture);
+    expect(result.fidelityWarnings).toContain("merged-cells-present");
+    expect(result.fidelityWarnings).toContain("markdown-lossy");
+  });
+
+  it("repeated-headers-table fixture triggers repeated-headers-detected", () => {
+    const fixture = loadFixture("repeated-headers-table");
+    const result = addFidelityWarnings(fixture);
+    expect(result.fidelityWarnings).toContain("repeated-headers-detected");
+  });
+
+  it("multipage-table fixture triggers multi-page-merged", () => {
+    const fixture = loadFixture("multipage-table");
+    const result = addFidelityWarnings(fixture);
+    expect(result.fidelityWarnings).toContain("multi-page-merged");
+  });
+
+  it("nested-headers-table fixture triggers headers-inferred", () => {
+    const fixture = loadFixture("nested-headers-table");
+    const result = addFidelityWarnings(fixture);
+    expect(result.fidelityWarnings).toContain("headers-inferred");
+  });
+
+  it("does not duplicate warnings when multiple conditions apply", () => {
+    const table: DocumentTable = {
+      ...baseTable,
+      cells: [{ ...baseTable.cells[0]!, rowSpan: 2 }, ...baseTable.cells.slice(1)],
+      continuity: { isMultiPage: true }
+    };
+    const result = addFidelityWarnings(table);
+    const warnings = result.fidelityWarnings ?? [];
+    expect(new Set(warnings).size).toBe(warnings.length);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export type {
 } from "./types/common";
 export type {
   DocumentTable,
+  FidelityWarning,
   HeaderGroup,
   PageSpan,
   TableCell,
@@ -27,6 +28,7 @@ export {
   boundingBoxSchema,
   continuitySchema,
   documentTableSchema,
+  fidelityWarningSchema,
   headerGroupSchema,
   pageSpanSchema,
   provenanceSchema,
@@ -43,6 +45,7 @@ export { buildRowGroupChunks, buildTableChunks } from "./chunk/build-table-chunk
 export { tableToHtml } from "./export/to-html";
 export { tableToJson } from "./export/to-json";
 export { tableToMarkdown } from "./export/to-markdown";
+export { addFidelityWarnings } from "./utils/fidelity-warnings";
 export { inferHeaders } from "./normalize/infer-headers";
 export type { MergeMultiPageTablesOptions } from "./normalize/merge-multipage";
 export { mergeMultiPageTables } from "./normalize/merge-multipage";

--- a/src/schema/zod.ts
+++ b/src/schema/zod.ts
@@ -82,6 +82,15 @@ export const continuitySchema = z.object({
   logicalTableGroupId: z.string().optional()
 });
 
+export const fidelityWarningSchema = z.enum([
+  "merged-cells-present",
+  "headers-inferred",
+  "markdown-lossy",
+  "repeated-headers-detected",
+  "ocr-noise-suspected",
+  "multi-page-merged"
+]);
+
 export const documentTableSchema = z.object({
   standardVersion: z.string().min(1),
   tableId: z.string().min(1),
@@ -100,7 +109,8 @@ export const documentTableSchema = z.object({
   headerGroups: z.array(headerGroupSchema).optional(),
   metadata: jsonRecordSchema.optional(),
   continuity: continuitySchema.optional(),
-  provenance: z.array(provenanceSchema).optional()
+  provenance: z.array(provenanceSchema).optional(),
+  fidelityWarnings: z.array(fidelityWarningSchema).optional()
 });
 
 export const tableChunkSchema = z.object({

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -62,6 +62,14 @@ export type TableContinuity = {
   logicalTableGroupId?: string;
 };
 
+export type FidelityWarning =
+  | "merged-cells-present"
+  | "headers-inferred"
+  | "markdown-lossy"
+  | "repeated-headers-detected"
+  | "ocr-noise-suspected"
+  | "multi-page-merged";
+
 export type DocumentTable = {
   standardVersion: string;
   tableId: string;
@@ -81,4 +89,5 @@ export type DocumentTable = {
   metadata?: JsonRecord;
   continuity?: TableContinuity;
   provenance?: Provenance[];
+  fidelityWarnings?: FidelityWarning[];
 };

--- a/src/utils/fidelity-warnings.ts
+++ b/src/utils/fidelity-warnings.ts
@@ -1,0 +1,59 @@
+import type { DocumentTable, FidelityWarning } from "../types/table";
+
+const OCR_EDIT_DISTANCE_THRESHOLD = 1;
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, (_, i) =>
+    Array.from({ length: n + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0))
+  );
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i]![j] =
+        a[i - 1] === b[j - 1]
+          ? dp[i - 1]![j - 1]!
+          : 1 + Math.min(dp[i - 1]![j]!, dp[i]![j - 1]!, dp[i - 1]![j - 1]!);
+    }
+  }
+  return dp[m]![n]!;
+}
+
+export function addFidelityWarnings(table: DocumentTable): DocumentTable {
+  const warnings = new Set<FidelityWarning>();
+
+  const hasMergedCells = table.cells.some(
+    (c) => (c.rowSpan !== undefined && c.rowSpan > 1) || (c.colSpan !== undefined && c.colSpan > 1)
+  );
+  if (hasMergedCells) {
+    warnings.add("merged-cells-present");
+    warnings.add("markdown-lossy");
+  }
+
+  if (table.cells.some((c) => c.inferredHeaders !== undefined && c.inferredHeaders.length > 0)) {
+    warnings.add("headers-inferred");
+  }
+
+  if (table.rows.some((r) => r.repeatedHeaderRow === true)) {
+    warnings.add("repeated-headers-detected");
+  }
+
+  if (
+    table.cells.some(
+      (c) =>
+        c.textRaw !== c.textNormalized &&
+        levenshtein(c.textRaw, c.textNormalized) > OCR_EDIT_DISTANCE_THRESHOLD
+    )
+  ) {
+    warnings.add("ocr-noise-suspected");
+  }
+
+  if (table.continuity?.isMultiPage === true) {
+    warnings.add("multi-page-merged");
+  }
+
+  return {
+    ...table,
+    fidelityWarnings: warnings.size > 0 ? [...warnings] : []
+  };
+}


### PR DESCRIPTION
## Summary
- Added `fidelityWarnings?: FidelityWarning[]` field to `documentTableSchema` (Zod) and `DocumentTable` TypeScript type
- Implemented `addFidelityWarnings(table)` utility that detects 6 warning conditions and returns a new (immutable) object
- Exported `addFidelityWarnings`, `FidelityWarning`, and `fidelityWarningSchema` from `index.ts`

## Changes
- `src/schema/zod.ts` — added `fidelityWarningSchema` enum + `fidelityWarnings` optional array field
- `src/types/table.ts` — added `FidelityWarning` union type + `fidelityWarnings` field on `DocumentTable`
- `src/utils/fidelity-warnings.ts` — new utility with Levenshtein-based OCR noise detection (threshold: edit distance > 1)
- `src/__tests__/fidelity.test.ts` — 23 tests covering each warning condition, immutability, no-duplicate guard, and all 12 fixtures
- `src/index.ts` — re-exports for new symbols

## Closes
Closes #15