### PR TITLE
feat: publish JSON Schema draft-07 as dist/schema.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,17 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+
+  validate-schema:
+    name: validate-schema
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run validate-schema

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
       },
       "devDependencies": {
         "@types/node": "^24.6.0",
+        "ajv": "^8.18.0",
+        "ajv-formats": "^3.0.1",
         "tsup": "^8.5.0",
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -1054,6 +1056,41 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -1264,6 +1301,30 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1323,6 +1384,13 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -1577,6 +1645,16 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "src/schema/json-schema.json"
   ],
   "sideEffects": false,
   "engines": {
@@ -27,7 +28,9 @@
     "clean": "rm -rf dist",
     "lint": "tsc --noEmit",
     "test": "vitest run",
-    "smoke": "node test/smoke/esm.mjs && node test/smoke/cjs.cjs"
+    "smoke": "node test/smoke/esm.mjs && node test/smoke/cjs.cjs",
+    "generate-schema": "node scripts/generate-schema.mjs",
+    "validate-schema": "node scripts/validate-fixtures.mjs"
   },
   "keywords": [
     "tables",
@@ -43,6 +46,8 @@
   },
   "devDependencies": {
     "@types/node": "^24.6.0",
+    "ajv": "^8.18.0",
+    "ajv-formats": "^3.0.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"

--- a/scripts/generate-schema.mjs
+++ b/scripts/generate-schema.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import { writeFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const { z } = await import("zod");
+const { documentTableSchema } = await import("../dist/index.js");
+
+const schema = z.toJSONSchema(documentTableSchema, {
+  target: "draft-7",
+  $schema: true
+});
+
+const outPath = join(__dirname, "../src/schema/json-schema.json");
+writeFileSync(outPath, JSON.stringify(schema, null, 2) + "\n");
+console.log("Generated src/schema/json-schema.json");

--- a/scripts/validate-fixtures.mjs
+++ b/scripts/validate-fixtures.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import { readFileSync, readdirSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "..");
+
+const schemaPath = join(root, "dist/schema.json");
+const fixturesDir = join(root, "src/fixtures");
+
+const schema = JSON.parse(readFileSync(schemaPath, "utf8"));
+const ajv = new Ajv({ strict: false });
+addFormats(ajv);
+const validate = ajv.compile(schema);
+
+const files = readdirSync(fixturesDir).filter((f) => f.endsWith(".json"));
+let passed = 0;
+let failed = 0;
+
+for (const file of files) {
+  const data = JSON.parse(readFileSync(join(fixturesDir, file), "utf8"));
+  const valid = validate(data);
+  if (valid) {
+    console.log(`  PASS  ${file}`);
+    passed++;
+  } else {
+    console.error(`  FAIL  ${file}`);
+    for (const err of validate.errors ?? []) {
+      console.error(`        ${err.instancePath} ${err.message}`);
+    }
+    failed++;
+  }
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,3 +58,5 @@ import type { DocumentTable } from "./types/table";
 export const validateTable = (input: unknown): DocumentTable => documentTableSchema.parse(input);
 
 export const safeValidateTable = (input: unknown) => documentTableSchema.safeParse(input);
+
+export { default as documentTableJsonSchema } from "./schema/json-schema.json";

--- a/src/schema/json-schema.json
+++ b/src/schema/json-schema.json
@@ -1,0 +1,444 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "standardVersion": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tableId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sourceDocumentId": {
+      "type": "string"
+    },
+    "sourceFileName": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "caption": {
+      "type": "string"
+    },
+    "sectionPath": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "footnotes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "pages": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 9007199254740991
+      }
+    },
+    "pageSpans": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "bbox": {
+            "type": "object",
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
+              "width": {
+                "type": "number"
+              },
+              "height": {
+                "type": "number"
+              },
+              "coordinateSpace": {
+                "type": "string",
+                "enum": [
+                  "pdf",
+                  "image",
+                  "normalized"
+                ]
+              }
+            },
+            "required": [
+              "x",
+              "y",
+              "width",
+              "height"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "page"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "columns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "colIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "label": {
+            "type": "string"
+          },
+          "inferredLabelPath": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "units": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          }
+        },
+        "required": [
+          "colIndex"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "rows": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "rowIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "rowType": {
+            "type": "string",
+            "enum": [
+              "header",
+              "body",
+              "footer",
+              "note"
+            ]
+          },
+          "cellIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "page": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "repeatedHeaderRow": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "rowIndex",
+          "cellIds"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "cells": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "cellId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "rowIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "colIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "textRaw": {
+            "type": "string"
+          },
+          "textNormalized": {
+            "type": "string"
+          },
+          "isHeader": {
+            "type": "boolean"
+          },
+          "headerLevel": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "rowSpan": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "colSpan": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "inferredHeaders": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "units": {
+            "type": "string"
+          },
+          "valueType": {
+            "type": "string",
+            "enum": [
+              "text",
+              "number",
+              "currency",
+              "percent",
+              "date",
+              "boolean",
+              "mixed"
+            ]
+          },
+          "bbox": {
+            "type": "object",
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
+              "width": {
+                "type": "number"
+              },
+              "height": {
+                "type": "number"
+              },
+              "coordinateSpace": {
+                "type": "string",
+                "enum": [
+                  "pdf",
+                  "image",
+                  "normalized"
+                ]
+              }
+            },
+            "required": [
+              "x",
+              "y",
+              "width",
+              "height"
+            ],
+            "additionalProperties": false
+          },
+          "page": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "sourceRefs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "page": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "extractor": {
+                  "type": "string"
+                },
+                "extractorVersion": {
+                  "type": "string"
+                },
+                "confidence": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1
+                }
+              },
+              "required": [
+                "page"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          }
+        },
+        "required": [
+          "cellId",
+          "rowIndex",
+          "colIndex",
+          "textRaw",
+          "textNormalized"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "headerGroups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "groupId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "label": {
+            "type": "string",
+            "minLength": 1
+          },
+          "level": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "colStart": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "colEnd": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": [
+          "groupId",
+          "label",
+          "level",
+          "colStart",
+          "colEnd"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {}
+    },
+    "continuity": {
+      "type": "object",
+      "properties": {
+        "isMultiPage": {
+          "type": "boolean"
+        },
+        "continuedFromPreviousPage": {
+          "type": "boolean"
+        },
+        "continuesOnNextPage": {
+          "type": "boolean"
+        },
+        "logicalTableGroupId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "isMultiPage"
+      ],
+      "additionalProperties": false
+    },
+    "provenance": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "step": {
+            "type": "string",
+            "minLength": 1
+          },
+          "tool": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "step"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "fidelityWarnings": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "merged-cells-present",
+          "headers-inferred",
+          "markdown-lossy",
+          "repeated-headers-detected",
+          "ocr-noise-suspected",
+          "multi-page-merged"
+        ]
+      }
+    }
+  },
+  "required": [
+    "standardVersion",
+    "tableId",
+    "pages",
+    "columns",
+    "rows",
+    "cells"
+  ],
+  "additionalProperties": false
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,3 +1,4 @@
+import { copyFileSync } from "fs";
 import { defineConfig } from "tsup";
 
 export default defineConfig({
@@ -6,5 +7,9 @@ export default defineConfig({
   dts: true,
   sourcemap: true,
   clean: true,
-  target: "node18"
+  target: "node18",
+  onSuccess: async () => {
+    copyFileSync("src/schema/json-schema.json", "dist/schema.json");
+    console.log("Copied src/schema/json-schema.json → dist/schema.json");
+  }
 });


### PR DESCRIPTION
## Summary

Generates a self-contained JSON Schema (draft-07) for `DocumentTable` from the existing Zod schema and publishes it as `dist/schema.json` in the npm tarball.

## Changes

- `src/schema/json-schema.json` — generated via `z.toJSONSchema(documentTableSchema, { target: "draft-7" })` (zod v4 built-in, no new prod dep)
- `tsup.config.ts` — `onSuccess` hook copies `src/schema/json-schema.json` → `dist/schema.json` on every build
- `src/index.ts` — exports `documentTableJsonSchema` (the JSON schema as a JS object)
- `scripts/generate-schema.mjs` — regenerate `src/schema/json-schema.json` from `dist/` after a build
- `scripts/validate-fixtures.mjs` — validates all `src/fixtures/*.json` against `dist/schema.json` using ajv (draft-07); all 12 fixtures pass
- `package.json` — adds `validate-schema` and `generate-schema` scripts; adds `src/schema/json-schema.json` to `files[]`; adds `ajv` + `ajv-formats` as devDeps
- `.github/workflows/ci.yml` — adds `validate-schema` job (runs after `build`)

## Closes

Closes #16