### PR TITLE
docs: add Session Start section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,3 +61,7 @@ src/
 ### Build output
 
 `tsup` emits dual ESM (`dist/index.js`) + CJS (`dist/index.cjs`) with `.d.ts` declarations. `src/index.ts` is the only entry point.
+
+### Session Start
+
+Every session begins by implementing /caveman and /token-efficiency


### PR DESCRIPTION
## Summary

- Adds a `### Session Start` section to `CLAUDE.md`
- Documents that every Claude Code session begins by implementing `/caveman` and `/token-efficiency`

## Changes

- `CLAUDE.md`: new `Session Start` subsection under Architecture

## Closes

Closes #46