### PR TITLE
feat: add conformance fixture pack with expected outputs

### DIFF
--- a/src/__tests__/conformance.test.ts
+++ b/src/__tests__/conformance.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import type { DocumentTable } from "../types/table";
+import { tableToHtml, tableToMarkdown, buildTableChunks } from "../index";
+
+const conformanceDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "fixtures",
+  "conformance"
+);
+
+const cases = readdirSync(conformanceDir, { withFileTypes: true })
+  .filter((d) => d.isDirectory())
+  .map((d) => d.name);
+
+describe("conformance fixtures", () => {
+  it.each(cases)("%s — expected-html.html matches tableToHtml output", (caseName) => {
+    const dir = path.join(conformanceDir, caseName);
+    const input = JSON.parse(readFileSync(path.join(dir, "input.json"), "utf8")) as DocumentTable;
+    const expected = readFileSync(path.join(dir, "expected-html.html"), "utf8");
+    expect(tableToHtml(input)).toBe(expected);
+  });
+
+  it.each(cases)("%s — expected-markdown.md matches tableToMarkdown output", (caseName) => {
+    const dir = path.join(conformanceDir, caseName);
+    const input = JSON.parse(readFileSync(path.join(dir, "input.json"), "utf8")) as DocumentTable;
+    const expected = readFileSync(path.join(dir, "expected-markdown.md"), "utf8");
+    expect(tableToMarkdown(input).markdown).toBe(expected);
+  });
+
+  it.each(cases)("%s — expected-chunks.json matches buildTableChunks output", (caseName) => {
+    const dir = path.join(conformanceDir, caseName);
+    const input = JSON.parse(readFileSync(path.join(dir, "input.json"), "utf8")) as DocumentTable;
+    const expected = JSON.parse(readFileSync(path.join(dir, "expected-chunks.json"), "utf8"));
+    expect(buildTableChunks(input)).toEqual(expected);
+  });
+});

--- a/src/fixtures/conformance/README.md
+++ b/src/fixtures/conformance/README.md
@@ -1,0 +1,68 @@
+# TPDS Conformance Fixture Pack
+
+This directory contains input/output snapshot pairs that define the canonical behaviour of the TPDS library.
+Third-party implementations can use these fixtures to verify conformance without running the TypeScript source.
+
+## Directory layout
+
+```
+conformance/
+  <case-name>/
+    input.json           DocumentTable JSON (source of truth)
+    expected-html.html   Output of tableToHtml(input)
+    expected-markdown.md Output of tableToMarkdown(input).markdown
+    expected-chunks.json Output of buildTableChunks(input) serialised as a JSON array
+```
+
+## Included cases
+
+| Case | Description |
+|---|---|
+| `simple-table` | Single-page table with headers, body rows, footnotes |
+| `merged-cells-table` | Table containing `rowspan`/`colspan` merged cells |
+| `multipage-table` | Table spanning multiple pages with continuation rows |
+
+## How to use
+
+### Asserting HTML output
+
+```js
+const input = JSON.parse(fs.readFileSync("simple-table/input.json", "utf8"));
+const expected = fs.readFileSync("simple-table/expected-html.html", "utf8");
+assert.strictEqual(yourTableToHtml(input), expected);
+```
+
+### Asserting Markdown output
+
+```js
+const result = yourTableToMarkdown(input);
+assert.strictEqual(result.markdown, expected);
+```
+
+### Asserting chunk output
+
+```js
+const expected = JSON.parse(fs.readFileSync("simple-table/expected-chunks.json", "utf8"));
+assert.deepStrictEqual(yourBuildTableChunks(input), expected);
+```
+
+## Updating snapshots
+
+Expected files are committed snapshots. If a change to the library intentionally alters output, regenerate them and commit the new snapshots in the same PR:
+
+```bash
+node --input-type=module << 'EOF'
+import { readFileSync, writeFileSync } from "node:fs";
+import { tableToHtml, tableToMarkdown, buildTableChunks } from "./dist/index.js";
+
+const cases = ["simple-table", "merged-cells-table", "multipage-table"];
+const base = "./src/fixtures/conformance";
+
+for (const c of cases) {
+  const input = JSON.parse(readFileSync(`${base}/${c}/input.json`, "utf8"));
+  writeFileSync(`${base}/${c}/expected-html.html`, tableToHtml(input));
+  writeFileSync(`${base}/${c}/expected-markdown.md`, tableToMarkdown(input).markdown);
+  writeFileSync(`${base}/${c}/expected-chunks.json`, JSON.stringify(buildTableChunks(input), null, 2) + "\n");
+}
+EOF
+```

--- a/src/fixtures/conformance/merged-cells-table/expected-chunks.json
+++ b/src/fixtures/conformance/merged-cells-table/expected-chunks.json
@@ -1,0 +1,63 @@
+[
+  {
+    "chunkId": "merged-cells-table:summary:0",
+    "tableId": "merged-cells-table",
+    "chunkType": "summary",
+    "text": "Table: Employee Counts by Department\nSection: Operations > Workforce\nPage Range: 8\nCaption: Department totals with merged top-level grouping headers.\nColumns: Department, Full Time, Contract",
+    "rowIndexes": [],
+    "pages": [
+      8
+    ],
+    "sectionPath": [
+      "Operations",
+      "Workforce"
+    ],
+    "title": "Employee Counts by Department",
+    "caption": "Department totals with merged top-level grouping headers.",
+    "tokenEstimate": 33,
+    "sourceRefs": []
+  },
+  {
+    "chunkId": "merged-cells-table:row:2",
+    "tableId": "merged-cells-table",
+    "chunkType": "row",
+    "text": "Table: Employee Counts by Department\nSection: Operations > Workforce\nPage Range: 8\n\nRow 2\nDepartment: Engineering\nFull Time: 82\nContract: 14",
+    "rowIndexes": [
+      2
+    ],
+    "pages": [
+      8
+    ],
+    "sectionPath": [
+      "Operations",
+      "Workforce"
+    ],
+    "title": "Employee Counts by Department",
+    "caption": "Department totals with merged top-level grouping headers.",
+    "tokenEstimate": 28,
+    "sourceRefs": []
+  },
+  {
+    "chunkId": "merged-cells-table:row-group:2-2",
+    "tableId": "merged-cells-table",
+    "chunkType": "row-group",
+    "text": "Table: Employee Counts by Department\nSection: Operations > Workforce\nPage Range: 8\n\nRow 2\nDepartment: Engineering\nFull Time: 82\nContract: 14",
+    "rowIndexes": [
+      2
+    ],
+    "pages": [
+      8
+    ],
+    "sectionPath": [
+      "Operations",
+      "Workforce"
+    ],
+    "title": "Employee Counts by Department",
+    "caption": "Department totals with merged top-level grouping headers.",
+    "tokenEstimate": 28,
+    "sourceRefs": [],
+    "metadata": {
+      "rowGroupSize": 5
+    }
+  }
+]

--- a/src/fixtures/conformance/merged-cells-table/expected-html.html
+++ b/src/fixtures/conformance/merged-cells-table/expected-html.html
@@ -1,0 +1,21 @@
+<table>
+  <caption>Department totals with merged top-level grouping headers.</caption>
+  <thead>
+  <tr>
+    <th rowspan="2" scope="col">Department</th>
+    <th colspan="2" scope="col">Headcount</th>
+  </tr>
+  <tr>
+    <th scope="col"></th>
+    <th scope="col">Full Time</th>
+    <th scope="col">Contract</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>Engineering</td>
+    <td>82</td>
+    <td>14</td>
+  </tr>
+  </tbody>
+</table>

--- a/src/fixtures/conformance/merged-cells-table/expected-markdown.md
+++ b/src/fixtures/conformance/merged-cells-table/expected-markdown.md
@@ -1,0 +1,8 @@
+Table: Employee Counts by Department
+Section: Operations > Workforce
+Pages: 8
+Caption: Department totals with merged top-level grouping headers.
+
+Row 0: Department | Headcount
+Row 1: | Full Time | Contract
+Row 2: Engineering | 82 | 14

--- a/src/fixtures/conformance/merged-cells-table/input.json
+++ b/src/fixtures/conformance/merged-cells-table/input.json
@@ -1,0 +1,34 @@
+{
+  "standardVersion": "1.0.0",
+  "tableId": "merged-cells-table",
+  "title": "Employee Counts by Department",
+  "caption": "Department totals with merged top-level grouping headers.",
+  "sectionPath": ["Operations", "Workforce"],
+  "pages": [8],
+  "columns": [
+    { "colIndex": 0, "label": "Department" },
+    { "colIndex": 1, "label": "Full Time" },
+    { "colIndex": 2, "label": "Contract" }
+  ],
+  "rows": [
+    { "rowIndex": 0, "rowType": "header", "cellIds": ["g0", "g1"], "page": 8 },
+    { "rowIndex": 1, "rowType": "header", "cellIds": ["h0", "h1", "h2"], "page": 8 },
+    { "rowIndex": 2, "rowType": "body", "cellIds": ["r2c0", "r2c1", "r2c2"], "page": 8 }
+  ],
+  "cells": [
+    { "cellId": "g0", "rowIndex": 0, "colIndex": 0, "textRaw": "Department", "textNormalized": "Department", "isHeader": true, "rowSpan": 2, "page": 8 },
+    { "cellId": "g1", "rowIndex": 0, "colIndex": 1, "textRaw": "Headcount", "textNormalized": "Headcount", "isHeader": true, "colSpan": 2, "page": 8 },
+    { "cellId": "h0", "rowIndex": 1, "colIndex": 0, "textRaw": "", "textNormalized": "", "isHeader": true, "page": 8 },
+    { "cellId": "h1", "rowIndex": 1, "colIndex": 1, "textRaw": "Full Time", "textNormalized": "Full Time", "isHeader": true, "page": 8 },
+    { "cellId": "h2", "rowIndex": 1, "colIndex": 2, "textRaw": "Contract", "textNormalized": "Contract", "isHeader": true, "page": 8 },
+    { "cellId": "r2c0", "rowIndex": 2, "colIndex": 0, "textRaw": "Engineering", "textNormalized": "Engineering", "page": 8 },
+    { "cellId": "r2c1", "rowIndex": 2, "colIndex": 1, "textRaw": "82", "textNormalized": "82", "page": 8, "valueType": "number" },
+    { "cellId": "r2c2", "rowIndex": 2, "colIndex": 2, "textRaw": "14", "textNormalized": "14", "page": 8, "valueType": "number" }
+  ],
+  "headerGroups": [
+    { "groupId": "headcount", "label": "Headcount", "level": 0, "colStart": 1, "colEnd": 2 }
+  ],
+  "continuity": {
+    "isMultiPage": false
+  }
+}

--- a/src/fixtures/conformance/multipage-table/expected-chunks.json
+++ b/src/fixtures/conformance/multipage-table/expected-chunks.json
@@ -1,0 +1,105 @@
+[
+  {
+    "chunkId": "multipage-table:summary:0",
+    "tableId": "multipage-table",
+    "chunkType": "summary",
+    "text": "Table: Shipment Delays by Port\nSection: Operations > Shipping\nPage Range: 20-21\nCaption: Continuation table across two pages.\nColumns: Port, Average Delay, Primary Cause",
+    "rowIndexes": [],
+    "pages": [
+      20,
+      21
+    ],
+    "sectionPath": [
+      "Operations",
+      "Shipping"
+    ],
+    "title": "Shipment Delays by Port",
+    "caption": "Continuation table across two pages.",
+    "tokenEstimate": 32,
+    "sourceRefs": []
+  },
+  {
+    "chunkId": "multipage-table:row:1",
+    "tableId": "multipage-table",
+    "chunkType": "row",
+    "text": "Table: Shipment Delays by Port\nSection: Operations > Shipping\nPage Range: 20-21\n\nRow 1\nPort: Halifax\nAverage Delay: 3 days\nPrimary Cause: Weather",
+    "rowIndexes": [
+      1
+    ],
+    "pages": [
+      20
+    ],
+    "sectionPath": [
+      "Operations",
+      "Shipping"
+    ],
+    "title": "Shipment Delays by Port",
+    "caption": "Continuation table across two pages.",
+    "tokenEstimate": 30,
+    "sourceRefs": []
+  },
+  {
+    "chunkId": "multipage-table:row:3",
+    "tableId": "multipage-table",
+    "chunkType": "row",
+    "text": "Table: Shipment Delays by Port\nSection: Operations > Shipping\nPage Range: 20-21\n\nRow 3\nPort: Montreal\nAverage Delay: 5 days\nPrimary Cause: Labor disruption",
+    "rowIndexes": [
+      3
+    ],
+    "pages": [
+      21
+    ],
+    "sectionPath": [
+      "Operations",
+      "Shipping"
+    ],
+    "title": "Shipment Delays by Port",
+    "caption": "Continuation table across two pages.",
+    "tokenEstimate": 32,
+    "sourceRefs": []
+  },
+  {
+    "chunkId": "multipage-table:row-group:1-3",
+    "tableId": "multipage-table",
+    "chunkType": "row-group",
+    "text": "Table: Shipment Delays by Port\nSection: Operations > Shipping\nPage Range: 20-21\n\nRow 1\nPort: Halifax\nAverage Delay: 3 days\nPrimary Cause: Weather\n\nTable: Shipment Delays by Port\nSection: Operations > Shipping\nPage Range: 20-21\n\nRow 3\nPort: Montreal\nAverage Delay: 5 days\nPrimary Cause: Labor disruption",
+    "rowIndexes": [
+      1,
+      3
+    ],
+    "pages": [
+      20,
+      21
+    ],
+    "sectionPath": [
+      "Operations",
+      "Shipping"
+    ],
+    "title": "Shipment Delays by Port",
+    "caption": "Continuation table across two pages.",
+    "tokenEstimate": 62,
+    "sourceRefs": [],
+    "metadata": {
+      "rowGroupSize": 5
+    }
+  },
+  {
+    "chunkId": "multipage-table:notes:0",
+    "tableId": "multipage-table",
+    "chunkType": "notes",
+    "text": "Notes:\n- Repeated header rows on continuation pages should not become new logical data rows.",
+    "rowIndexes": [],
+    "pages": [
+      20,
+      21
+    ],
+    "sectionPath": [
+      "Operations",
+      "Shipping"
+    ],
+    "title": "Shipment Delays by Port",
+    "caption": "Continuation table across two pages.",
+    "tokenEstimate": 20,
+    "sourceRefs": []
+  }
+]

--- a/src/fixtures/conformance/multipage-table/expected-html.html
+++ b/src/fixtures/conformance/multipage-table/expected-html.html
@@ -1,0 +1,28 @@
+<table>
+  <caption>Continuation table across two pages.</caption>
+  <thead>
+  <tr>
+    <th scope="col">Port</th>
+    <th scope="col">Average Delay</th>
+    <th scope="col">Primary Cause</th>
+  </tr>
+  <tr>
+    <th scope="col">Port</th>
+    <th scope="col">Average Delay</th>
+    <th scope="col">Primary Cause</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>Halifax</td>
+    <td>3 days</td>
+    <td>Weather</td>
+  </tr>
+  <tr>
+    <td>Montreal</td>
+    <td>5 days</td>
+    <td>Labor disruption</td>
+  </tr>
+  </tbody>
+</table>
+<div class="tpds-notes"><p>Repeated header rows on continuation pages should not become new logical data rows.</p></div>

--- a/src/fixtures/conformance/multipage-table/expected-markdown.md
+++ b/src/fixtures/conformance/multipage-table/expected-markdown.md
@@ -1,0 +1,6 @@
+> Continuation table across two pages.
+
+| Port | Average Delay | Primary Cause |
+| --- | --- | --- |
+| Halifax | 3 days | Weather |
+| Montreal | 5 days | Labor disruption |

--- a/src/fixtures/conformance/multipage-table/input.json
+++ b/src/fixtures/conformance/multipage-table/input.json
@@ -1,0 +1,42 @@
+{
+  "standardVersion": "1.0.0",
+  "tableId": "multipage-table",
+  "sourceDocumentId": "doc-supply-chain",
+  "title": "Shipment Delays by Port",
+  "caption": "Continuation table across two pages.",
+  "sectionPath": ["Operations", "Shipping"],
+  "notes": ["Repeated header rows on continuation pages should not become new logical data rows."],
+  "pages": [20, 21],
+  "pageSpans": [{ "page": 20 }, { "page": 21 }],
+  "columns": [
+    { "colIndex": 0, "label": "Port" },
+    { "colIndex": 1, "label": "Average Delay" },
+    { "colIndex": 2, "label": "Primary Cause" }
+  ],
+  "rows": [
+    { "rowIndex": 0, "rowType": "header", "cellIds": ["h0", "h1", "h2"], "page": 20 },
+    { "rowIndex": 1, "rowType": "body", "cellIds": ["r1c0", "r1c1", "r1c2"], "page": 20 },
+    { "rowIndex": 2, "rowType": "header", "cellIds": ["h3", "h4", "h5"], "page": 21, "repeatedHeaderRow": true },
+    { "rowIndex": 3, "rowType": "body", "cellIds": ["r3c0", "r3c1", "r3c2"], "page": 21 }
+  ],
+  "cells": [
+    { "cellId": "h0", "rowIndex": 0, "colIndex": 0, "textRaw": "Port", "textNormalized": "Port", "isHeader": true, "page": 20 },
+    { "cellId": "h1", "rowIndex": 0, "colIndex": 1, "textRaw": "Average Delay", "textNormalized": "Average Delay", "isHeader": true, "page": 20 },
+    { "cellId": "h2", "rowIndex": 0, "colIndex": 2, "textRaw": "Primary Cause", "textNormalized": "Primary Cause", "isHeader": true, "page": 20 },
+    { "cellId": "r1c0", "rowIndex": 1, "colIndex": 0, "textRaw": "Halifax", "textNormalized": "Halifax", "page": 20 },
+    { "cellId": "r1c1", "rowIndex": 1, "colIndex": 1, "textRaw": "3 days", "textNormalized": "3 days", "page": 20 },
+    { "cellId": "r1c2", "rowIndex": 1, "colIndex": 2, "textRaw": "Weather", "textNormalized": "Weather", "page": 20 },
+    { "cellId": "h3", "rowIndex": 2, "colIndex": 0, "textRaw": "Port", "textNormalized": "Port", "isHeader": true, "page": 21 },
+    { "cellId": "h4", "rowIndex": 2, "colIndex": 1, "textRaw": "Average Delay", "textNormalized": "Average Delay", "isHeader": true, "page": 21 },
+    { "cellId": "h5", "rowIndex": 2, "colIndex": 2, "textRaw": "Primary Cause", "textNormalized": "Primary Cause", "isHeader": true, "page": 21 },
+    { "cellId": "r3c0", "rowIndex": 3, "colIndex": 0, "textRaw": "Montreal", "textNormalized": "Montreal", "page": 21 },
+    { "cellId": "r3c1", "rowIndex": 3, "colIndex": 1, "textRaw": "5 days", "textNormalized": "5 days", "page": 21 },
+    { "cellId": "r3c2", "rowIndex": 3, "colIndex": 2, "textRaw": "Labor disruption", "textNormalized": "Labor disruption", "page": 21 }
+  ],
+  "continuity": {
+    "isMultiPage": true,
+    "logicalTableGroupId": "shipment-delays",
+    "continuesOnNextPage": false,
+    "continuedFromPreviousPage": false
+  }
+}

--- a/src/fixtures/conformance/simple-table/expected-chunks.json
+++ b/src/fixtures/conformance/simple-table/expected-chunks.json
@@ -1,0 +1,130 @@
+[
+  {
+    "chunkId": "simple-table:summary:0",
+    "tableId": "simple-table",
+    "chunkType": "summary",
+    "text": "Table: Revenue by Quarter\nSection: Financial Results > Q1 2025\nPage Range: 14\nCaption: Quarterly revenue and margin by region.\nColumns: Quarter, Region, Revenue, Operating Margin",
+    "rowIndexes": [],
+    "pages": [
+      14
+    ],
+    "sectionPath": [
+      "Financial Results",
+      "Q1 2025"
+    ],
+    "title": "Revenue by Quarter",
+    "caption": "Quarterly revenue and margin by region.",
+    "tokenEstimate": 34,
+    "sourceRefs": [
+      {
+        "page": 14,
+        "extractor": "fixture",
+        "extractorVersion": "1.0.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "chunkId": "simple-table:row:1",
+    "tableId": "simple-table",
+    "chunkType": "row",
+    "text": "Table: Revenue by Quarter\nSection: Financial Results > Q1 2025\nPage Range: 14\n\nRow 1\nQuarter: Q1 2025\nRegion: North America\nRevenue: 12.4M\nOperating Margin: 18%",
+    "rowIndexes": [
+      1
+    ],
+    "pages": [
+      14
+    ],
+    "sectionPath": [
+      "Financial Results",
+      "Q1 2025"
+    ],
+    "title": "Revenue by Quarter",
+    "caption": "Quarterly revenue and margin by region.",
+    "tokenEstimate": 34,
+    "sourceRefs": [
+      {
+        "page": 14,
+        "extractor": "fixture",
+        "extractorVersion": "1.0.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "chunkId": "simple-table:row:2",
+    "tableId": "simple-table",
+    "chunkType": "row",
+    "text": "Table: Revenue by Quarter\nSection: Financial Results > Q1 2025\nPage Range: 14\n\nRow 2\nQuarter: Q1 2025\nRegion: Europe\nRevenue: 9.7M\nOperating Margin: 16%",
+    "rowIndexes": [
+      2
+    ],
+    "pages": [
+      14
+    ],
+    "sectionPath": [
+      "Financial Results",
+      "Q1 2025"
+    ],
+    "title": "Revenue by Quarter",
+    "caption": "Quarterly revenue and margin by region.",
+    "tokenEstimate": 33,
+    "sourceRefs": []
+  },
+  {
+    "chunkId": "simple-table:row-group:1-2",
+    "tableId": "simple-table",
+    "chunkType": "row-group",
+    "text": "Table: Revenue by Quarter\nSection: Financial Results > Q1 2025\nPage Range: 14\n\nRow 1\nQuarter: Q1 2025\nRegion: North America\nRevenue: 12.4M\nOperating Margin: 18%\n\nTable: Revenue by Quarter\nSection: Financial Results > Q1 2025\nPage Range: 14\n\nRow 2\nQuarter: Q1 2025\nRegion: Europe\nRevenue: 9.7M\nOperating Margin: 16%",
+    "rowIndexes": [
+      1,
+      2
+    ],
+    "pages": [
+      14
+    ],
+    "sectionPath": [
+      "Financial Results",
+      "Q1 2025"
+    ],
+    "title": "Revenue by Quarter",
+    "caption": "Quarterly revenue and margin by region.",
+    "tokenEstimate": 67,
+    "sourceRefs": [
+      {
+        "page": 14,
+        "extractor": "fixture",
+        "extractorVersion": "1.0.0",
+        "confidence": 1
+      }
+    ],
+    "metadata": {
+      "rowGroupSize": 5
+    }
+  },
+  {
+    "chunkId": "simple-table:notes:0",
+    "tableId": "simple-table",
+    "chunkType": "notes",
+    "text": "Notes:\n- Revenue values are unaudited.\n\nFootnotes:\n- Operating margin is shown after regional allocations.\n\nUnits:\n- Revenue: USD millions\n- Operating Margin: percent",
+    "rowIndexes": [],
+    "pages": [
+      14
+    ],
+    "sectionPath": [
+      "Financial Results",
+      "Q1 2025"
+    ],
+    "title": "Revenue by Quarter",
+    "caption": "Quarterly revenue and margin by region.",
+    "tokenEstimate": 32,
+    "sourceRefs": [
+      {
+        "page": 14,
+        "extractor": "fixture",
+        "extractorVersion": "1.0.0",
+        "confidence": 1
+      }
+    ]
+  }
+]

--- a/src/fixtures/conformance/simple-table/expected-html.html
+++ b/src/fixtures/conformance/simple-table/expected-html.html
@@ -1,0 +1,27 @@
+<table>
+  <caption>Quarterly revenue and margin by region.</caption>
+  <thead>
+  <tr>
+    <th scope="col">Quarter</th>
+    <th scope="col">Region</th>
+    <th scope="col">Revenue</th>
+    <th scope="col">Operating Margin</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>Q1 2025</td>
+    <td>North America</td>
+    <td>12.4M</td>
+    <td>18%</td>
+  </tr>
+  <tr>
+    <td>Q1 2025</td>
+    <td>Europe</td>
+    <td>9.7M</td>
+    <td>16%</td>
+  </tr>
+  </tbody>
+</table>
+<div class="tpds-notes"><p>Revenue values are unaudited.</p></div>
+<div class="tpds-footnotes"><p>Operating margin is shown after regional allocations.</p></div>

--- a/src/fixtures/conformance/simple-table/expected-markdown.md
+++ b/src/fixtures/conformance/simple-table/expected-markdown.md
@@ -1,0 +1,8 @@
+> Quarterly revenue and margin by region.
+
+| Quarter | Region | Revenue | Operating Margin |
+| --- | --- | --- | --- |
+| Q1 2025 | North America | 12.4M | 18% |
+| Q1 2025 | Europe | 9.7M | 16% |
+
+_Operating margin is shown after regional allocations._

--- a/src/fixtures/conformance/simple-table/input.json
+++ b/src/fixtures/conformance/simple-table/input.json
@@ -1,0 +1,103 @@
+{
+  "standardVersion": "1.0.0",
+  "tableId": "simple-table",
+  "sourceDocumentId": "doc-financials-2025",
+  "sourceFileName": "financial-results-q1.pdf",
+  "title": "Revenue by Quarter",
+  "caption": "Quarterly revenue and margin by region.",
+  "sectionPath": ["Financial Results", "Q1 2025"],
+  "notes": ["Revenue values are unaudited."],
+  "footnotes": ["Operating margin is shown after regional allocations."],
+  "pages": [14],
+  "columns": [
+    { "colIndex": 0, "label": "Quarter" },
+    { "colIndex": 1, "label": "Region" },
+    { "colIndex": 2, "label": "Revenue", "units": "USD millions" },
+    { "colIndex": 3, "label": "Operating Margin", "units": "percent" }
+  ],
+  "rows": [
+    { "rowIndex": 0, "rowType": "header", "cellIds": ["h0", "h1", "h2", "h3"], "page": 14 },
+    { "rowIndex": 1, "rowType": "body", "cellIds": ["r1c0", "r1c1", "r1c2", "r1c3"], "page": 14 },
+    { "rowIndex": 2, "rowType": "body", "cellIds": ["r2c0", "r2c1", "r2c2", "r2c3"], "page": 14 }
+  ],
+  "cells": [
+    { "cellId": "h0", "rowIndex": 0, "colIndex": 0, "textRaw": "Quarter", "textNormalized": "Quarter", "isHeader": true, "page": 14 },
+    { "cellId": "h1", "rowIndex": 0, "colIndex": 1, "textRaw": "Region", "textNormalized": "Region", "isHeader": true, "page": 14 },
+    { "cellId": "h2", "rowIndex": 0, "colIndex": 2, "textRaw": "Revenue", "textNormalized": "Revenue", "isHeader": true, "page": 14 },
+    { "cellId": "h3", "rowIndex": 0, "colIndex": 3, "textRaw": "Operating Margin", "textNormalized": "Operating Margin", "isHeader": true, "page": 14 },
+    {
+      "cellId": "r1c0",
+      "rowIndex": 1,
+      "colIndex": 0,
+      "textRaw": "Q1 2025",
+      "textNormalized": "Q1 2025",
+      "page": 14,
+      "sourceRefs": [{ "page": 14, "extractor": "fixture", "extractorVersion": "1.0.0", "confidence": 1 }]
+    },
+    {
+      "cellId": "r1c1",
+      "rowIndex": 1,
+      "colIndex": 1,
+      "textRaw": "North America",
+      "textNormalized": "North America",
+      "page": 14
+    },
+    {
+      "cellId": "r1c2",
+      "rowIndex": 1,
+      "colIndex": 2,
+      "textRaw": "12.4M",
+      "textNormalized": "12.4M",
+      "page": 14,
+      "valueType": "currency",
+      "units": "USD millions"
+    },
+    {
+      "cellId": "r1c3",
+      "rowIndex": 1,
+      "colIndex": 3,
+      "textRaw": "18%",
+      "textNormalized": "18%",
+      "page": 14,
+      "valueType": "percent"
+    },
+    {
+      "cellId": "r2c0",
+      "rowIndex": 2,
+      "colIndex": 0,
+      "textRaw": "Q1 2025",
+      "textNormalized": "Q1 2025",
+      "page": 14
+    },
+    {
+      "cellId": "r2c1",
+      "rowIndex": 2,
+      "colIndex": 1,
+      "textRaw": "Europe",
+      "textNormalized": "Europe",
+      "page": 14
+    },
+    {
+      "cellId": "r2c2",
+      "rowIndex": 2,
+      "colIndex": 2,
+      "textRaw": "9.7M",
+      "textNormalized": "9.7M",
+      "page": 14,
+      "valueType": "currency",
+      "units": "USD millions"
+    },
+    {
+      "cellId": "r2c3",
+      "rowIndex": 2,
+      "colIndex": 3,
+      "textRaw": "16%",
+      "textNormalized": "16%",
+      "page": 14,
+      "valueType": "percent"
+    }
+  ],
+  "provenance": [
+    { "step": "fixture-authoring", "tool": "manual", "version": "1.0.0", "timestamp": "2026-04-18T00:00:00Z" }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `src/fixtures/conformance/` with three cases: `simple-table`, `merged-cells-table`, `multipage-table`
- Each case contains `input.json` plus committed snapshot files for `tableToHtml`, `tableToMarkdown`, and `buildTableChunks` output
- `src/__tests__/conformance.test.ts` reads each pair and asserts exact match (9 new tests, total 78)
- `src/fixtures/conformance/README.md` explains the pack format for third-party implementations

## Changes

- `src/__tests__/conformance.test.ts` — conformance test suite, dynamically discovers cases via `readdirSync`
- `src/fixtures/conformance/<case>/input.json` — copied from existing fixtures
- `src/fixtures/conformance/<case>/expected-html.html` — snapshot of `tableToHtml` output
- `src/fixtures/conformance/<case>/expected-markdown.md` — snapshot of `tableToMarkdown().markdown`
- `src/fixtures/conformance/<case>/expected-chunks.json` — snapshot of `buildTableChunks` output
- `src/fixtures/conformance/README.md` — explains format, update procedure, and usage examples

## Closes

Closes #17

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm test` passes (78 tests, +9 conformance)
- [ ] `npm run build` succeeds
- [ ] `npm run validate-schema` passes (12/12)
- [ ] Conformance test fails if any snapshot file is modified without updating the expected output