### PR TITLE
feat: add normalizeFromFlatArray adapter

### DIFF
--- a/src/__tests__/adapter-flat-array.test.ts
+++ b/src/__tests__/adapter-flat-array.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeFromFlatArray } from "../index";
+import { validateTable } from "../index";
+
+describe("normalizeFromFlatArray", () => {
+  it("basic 3-column table with header row", () => {
+    const rows = [
+      ["Name", "Age", "City"],
+      ["Alice", "30", "NYC"],
+      ["Bob", "25", "LA"],
+    ];
+    const table = normalizeFromFlatArray(rows);
+
+    expect(validateTable(table)).toBeTruthy();
+    expect(table.columns).toHaveLength(3);
+
+    const headerRow = table.rows.find((r) => r.rowType === "header");
+    expect(headerRow).toBeDefined();
+
+    const cellMap = Object.fromEntries(table.cells.map((c) => [c.cellId, c]));
+    const headerCells = headerRow!.cellIds.map((id) => cellMap[id]);
+    expect(headerCells.map((c) => c?.textRaw)).toEqual(["Name", "Age", "City"]);
+    expect(headerCells.every((c) => c?.isHeader === true)).toBe(true);
+
+    const bodyRows = table.rows.filter((r) => r.rowType === "body");
+    expect(bodyRows).toHaveLength(2);
+  });
+
+  it("firstRowIsHeader: false — all rows become body rows", () => {
+    const rows = [
+      ["Alice", "30", "NYC"],
+      ["Bob", "25", "LA"],
+    ];
+    const table = normalizeFromFlatArray(rows, { firstRowIsHeader: false });
+
+    expect(validateTable(table)).toBeTruthy();
+    expect(table.rows.every((r) => r.rowType === "body")).toBe(true);
+    const cellMap2 = Object.fromEntries(table.cells.map((c) => [c.cellId, c]));
+    expect(table.rows.every((r) =>
+      r.cellIds.every((id) => cellMap2[id]?.isHeader === false)
+    )).toBe(true);
+  });
+
+  it("empty input throws", () => {
+    expect(() => normalizeFromFlatArray([])).toThrow();
+  });
+
+  it("single-row input with firstRowIsHeader: true produces header-only table", () => {
+    const rows = [["Col A", "Col B"]];
+    const table = normalizeFromFlatArray(rows);
+
+    expect(validateTable(table)).toBeTruthy();
+    expect(table.rows).toHaveLength(1);
+    expect(table.rows[0]?.rowType).toBe("header");
+  });
+
+  it("options: tableId and title propagate", () => {
+    const rows = [["X"], ["1"]];
+    const table = normalizeFromFlatArray(rows, {
+      tableId: "my-table-id",
+      title: "My Table",
+    });
+
+    expect(table.tableId).toBe("my-table-id");
+    expect(table.title).toBe("My Table");
+  });
+});

--- a/src/adapters/from-flat-array.ts
+++ b/src/adapters/from-flat-array.ts
@@ -1,0 +1,82 @@
+import { normalizeTable } from "../normalize/normalize-table";
+import type { DocumentTable } from "../types/table";
+import { createId } from "../utils/ids";
+import { normalizeText } from "../utils/text";
+
+export type FlatArrayAdapterOptions = {
+  firstRowIsHeader?: boolean;
+  tableId?: string;
+  title?: string;
+  sectionPath?: string[];
+  pages?: number[];
+  standardVersion?: string;
+};
+
+export function normalizeFromFlatArray(
+  rows: string[][],
+  options: FlatArrayAdapterOptions = {}
+): DocumentTable {
+  if (rows.length === 0) {
+    throw new Error("normalizeFromFlatArray: rows must not be empty");
+  }
+
+  const {
+    firstRowIsHeader = true,
+    tableId = createId("tbl"),
+    title,
+    sectionPath,
+    pages = [1],
+    standardVersion,
+  } = options;
+
+  const firstRow = rows[0];
+  if (firstRow === undefined) {
+    throw new Error("normalizeFromFlatArray: rows must not be empty");
+  }
+  const colCount = firstRow.length;
+
+  const cells: Record<string, unknown>[] = [];
+  const rowObjects: unknown[] = [];
+
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    const row = rows[rowIndex];
+    if (row === undefined) continue;
+
+    const isHeaderRow = firstRowIsHeader && rowIndex === 0;
+    const rowType = isHeaderRow ? "header" : "body";
+    for (let colIndex = 0; colIndex < colCount; colIndex++) {
+      const textRaw = row[colIndex] ?? "";
+      cells.push({
+        rowIndex,
+        colIndex,
+        textRaw,
+        textNormalized: normalizeText(textRaw),
+        isHeader: isHeaderRow,
+      });
+    }
+
+    rowObjects.push({
+      rowIndex,
+      rowType,
+      page: pages[0] ?? 1,
+    });
+  }
+
+  const columns = Array.from({ length: colCount }, (_, i) => ({
+    colIndex: i,
+  }));
+
+  const raw: Record<string, unknown> = {
+    tableId,
+    pages,
+    columns,
+    rows: rowObjects,
+    cells,
+  };
+
+  if (title !== undefined) raw["title"] = title;
+  if (sectionPath !== undefined) raw["sectionPath"] = sectionPath;
+  if (standardVersion !== undefined) raw["standardVersion"] = standardVersion;
+
+  return normalizeTable(raw);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,8 @@ export type { MergeMultiPageTablesOptions } from "./normalize/merge-multipage";
 export { mergeMultiPageTables } from "./normalize/merge-multipage";
 export type { NormalizeTableOptions } from "./normalize/normalize-table";
 export { normalizeTable } from "./normalize/normalize-table";
+export type { FlatArrayAdapterOptions } from "./adapters/from-flat-array";
+export { normalizeFromFlatArray } from "./adapters/from-flat-array";
 
 import { documentTableSchema } from "./schema/zod";
 import type { DocumentTable } from "./types/table";


### PR DESCRIPTION
## Summary

- Adds `src/adapters/from-flat-array.ts` with `normalizeFromFlatArray(rows, options?)` and `FlatArrayAdapterOptions`
- Exports both from `src/index.ts`
- 5 new tests in `src/__tests__/adapter-flat-array.test.ts` (83 total passing)

## Changes

- **NEW** `src/adapters/from-flat-array.ts` — adapter that converts `string[][]` to `DocumentTable` via `normalizeTable`
- **NEW** `src/__tests__/adapter-flat-array.test.ts` — covers header row, firstRowIsHeader:false, empty input error, single-row, option propagation
- **MOD** `src/index.ts` — exports `normalizeFromFlatArray` and `FlatArrayAdapterOptions`

## Closes

Closes #18