### PR TITLE
feat: add normalizeFromDocling adapter

### DIFF
--- a/src/__tests__/adapter-docling.test.ts
+++ b/src/__tests__/adapter-docling.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import doclingFixture from "../fixtures/adapters/docling-input.json";
+import { normalizeFromDocling, validateTable } from "../index";
+
+describe("normalizeFromDocling", () => {
+  it("fixture normalizes without throwing", () => {
+    expect(() => normalizeFromDocling(doclingFixture)).not.toThrow();
+  });
+
+  it("result passes validateTable", () => {
+    const table = normalizeFromDocling(doclingFixture);
+    expect(validateTable(table)).toBeTruthy();
+  });
+
+  it("header cells mapped correctly — isHeader true and rowType header", () => {
+    const table = normalizeFromDocling(doclingFixture);
+
+    const headerRow = table.rows.find((r) => r.rowType === "header");
+    expect(headerRow).toBeDefined();
+
+    const cellMap = Object.fromEntries(table.cells.map((c) => [c.cellId, c]));
+    const headerCells = headerRow!.cellIds.map((id) => cellMap[id]);
+    expect(headerCells.every((c) => c?.isHeader === true)).toBe(true);
+    expect(headerCells.map((c) => c?.textRaw)).toEqual(["Product", "Q1 Revenue", "Q2 Revenue"]);
+  });
+
+  it("rowSpan and colSpan mapped from grid cell spans", () => {
+    const table = normalizeFromDocling(doclingFixture);
+    const cellMap = Object.fromEntries(table.cells.map((c) => [c.cellId, c]));
+
+    // "Widget A" at row 1, col 0 has row_span: 2
+    const widgetACell = Object.values(cellMap).find(
+      (c) => c?.textRaw === "Widget A" && c.rowIndex === 1
+    );
+    expect(widgetACell).toBeDefined();
+    expect(widgetACell?.rowSpan).toBe(2);
+
+    // "950" at row 2, col 1 has col_span: 2
+    const ninetyFiftyCell = Object.values(cellMap).find(
+      (c) => c?.textRaw === "950" && c.rowIndex === 2
+    );
+    expect(ninetyFiftyCell).toBeDefined();
+    expect(ninetyFiftyCell?.colSpan).toBe(2);
+  });
+
+  it("caption propagated from options", () => {
+    const table = normalizeFromDocling(doclingFixture, { caption: "Revenue by Product" });
+    expect(table.caption).toBe("Revenue by Product");
+  });
+
+  it("page number extracted from prov", () => {
+    const table = normalizeFromDocling(doclingFixture);
+    expect(table.pages).toContain(2);
+  });
+
+  it("invalid input throws", () => {
+    expect(() => normalizeFromDocling(null)).toThrow();
+    expect(() => normalizeFromDocling(42)).toThrow();
+  });
+});

--- a/src/adapters/from-docling.ts
+++ b/src/adapters/from-docling.ts
@@ -1,0 +1,123 @@
+import { normalizeTable } from "../normalize/normalize-table";
+import type { NormalizeTableOptions } from "../normalize/normalize-table";
+import type { DocumentTable } from "../types/table";
+import { createId } from "../utils/ids";
+import { normalizeText } from "../utils/text";
+
+export type NormalizeDoclingOptions = NormalizeTableOptions & {
+  tableId?: string;
+  title?: string;
+  caption?: string;
+  sourceDocumentId?: string;
+};
+
+export function normalizeFromDocling(
+  tableItem: unknown,
+  options: NormalizeDoclingOptions = {}
+): DocumentTable {
+  if (tableItem === null || typeof tableItem !== "object" || Array.isArray(tableItem)) {
+    throw new Error("normalizeFromDocling: tableItem must be a non-null object");
+  }
+
+  const item = tableItem as Record<string, unknown>;
+  const data = (typeof item.data === "object" && item.data !== null && !Array.isArray(item.data))
+    ? (item.data as Record<string, unknown>)
+    : {};
+
+  const grid = Array.isArray(data.grid) ? (data.grid as unknown[][]) : [];
+  const prov = Array.isArray(item.prov) ? (item.prov as unknown[]) : [];
+
+  if (grid.length === 0) {
+    throw new Error("normalizeFromDocling: tableItem.data.grid must be a non-empty array");
+  }
+
+  const tableId = options.tableId ?? createId("tbl");
+
+  const pages: number[] = prov.length > 0
+    ? [...new Set(
+        prov
+          .map((p) => {
+            const po = p as Record<string, unknown>;
+            return typeof po.page_no === "number" ? po.page_no : undefined;
+          })
+          .filter((n): n is number => n !== undefined)
+      )]
+    : [1];
+
+  const cells: Record<string, unknown>[] = [];
+  const rowObjects: unknown[] = [];
+
+  for (let rowIndex = 0; rowIndex < grid.length; rowIndex++) {
+    const gridRow = Array.isArray(grid[rowIndex]) ? (grid[rowIndex] as unknown[]) : [];
+    let rowIsHeader = false;
+
+    for (let colIndex = 0; colIndex < gridRow.length; colIndex++) {
+      const gridCell = gridRow[colIndex];
+      if (gridCell === null || typeof gridCell !== "object" || Array.isArray(gridCell)) continue;
+      const gc = gridCell as Record<string, unknown>;
+
+      const startRow = typeof gc.start_row_offset_idx === "number" ? gc.start_row_offset_idx : rowIndex;
+      const startCol = typeof gc.start_col_offset_idx === "number" ? gc.start_col_offset_idx : colIndex;
+
+      if (startRow !== rowIndex || startCol !== colIndex) continue;
+
+      const colHeader = gc.column_header === true;
+      const rowHeader = gc.row_header === true;
+      const isHeader = colHeader || rowHeader;
+      if (colHeader) rowIsHeader = true;
+
+      const rowSpan = typeof gc.row_span === "number" && gc.row_span > 1 ? gc.row_span : undefined;
+      const colSpan = typeof gc.col_span === "number" && gc.col_span > 1 ? gc.col_span : undefined;
+
+      const textRaw = typeof gc.text === "string" ? gc.text : "";
+
+      const cell: Record<string, unknown> = {
+        rowIndex,
+        colIndex,
+        textRaw,
+        textNormalized: normalizeText(textRaw),
+        isHeader,
+      };
+      if (rowSpan !== undefined) cell["rowSpan"] = rowSpan;
+      if (colSpan !== undefined) cell["colSpan"] = colSpan;
+
+      cells.push(cell);
+    }
+
+    rowObjects.push({
+      rowIndex,
+      rowType: rowIsHeader ? "header" : "body",
+      page: pages[0] ?? 1,
+    });
+  }
+
+  const numCols =
+    typeof data.num_cols === "number"
+      ? data.num_cols
+      : Array.isArray(grid[0])
+        ? (grid[0] as unknown[]).length
+        : 0;
+
+  const columns = Array.from({ length: numCols }, (_, i) => ({ colIndex: i }));
+
+  const caption =
+    options.caption ??
+    (typeof item.caption === "string" ? item.caption : undefined);
+
+  const raw: Record<string, unknown> = {
+    tableId,
+    pages,
+    columns,
+    rows: rowObjects,
+    cells,
+  };
+
+  if (caption !== undefined) raw["caption"] = caption;
+  if (options.title !== undefined) raw["title"] = options.title;
+  if (options.sourceDocumentId !== undefined) raw["sourceDocumentId"] = options.sourceDocumentId;
+
+  return normalizeTable(raw, {
+    standardVersion: options.standardVersion,
+    inferHeaders: options.inferHeaders,
+  });
+}

--- a/src/fixtures/adapters/docling-input.json
+++ b/src/fixtures/adapters/docling-input.json
@@ -1,0 +1,239 @@
+{
+  "self_ref": "#/tables/0",
+  "parent": { "$ref": "#/body" },
+  "children": [],
+  "content_layer": "body",
+  "label": "table",
+  "prov": [
+    {
+      "page_no": 2,
+      "bbox": { "l": 72.0, "t": 150.0, "r": 540.0, "b": 400.0, "coord_origin": "BOTTOMLEFT" },
+      "charspan": [0, 0]
+    }
+  ],
+  "captions": [{ "$ref": "#/texts/3" }],
+  "references": [],
+  "footnotes": [],
+  "data": {
+    "table_cells": [
+      {
+        "text": "Product",
+        "bbox": null,
+        "row_span": 1,
+        "col_span": 1,
+        "start_row_offset_idx": 0,
+        "end_row_offset_idx": 1,
+        "start_col_offset_idx": 0,
+        "end_col_offset_idx": 1,
+        "column_header": true,
+        "row_header": false,
+        "row_section": false
+      },
+      {
+        "text": "Q1 Revenue",
+        "bbox": null,
+        "row_span": 1,
+        "col_span": 1,
+        "start_row_offset_idx": 0,
+        "end_row_offset_idx": 1,
+        "start_col_offset_idx": 1,
+        "end_col_offset_idx": 2,
+        "column_header": true,
+        "row_header": false,
+        "row_section": false
+      },
+      {
+        "text": "Q2 Revenue",
+        "bbox": null,
+        "row_span": 1,
+        "col_span": 1,
+        "start_row_offset_idx": 0,
+        "end_row_offset_idx": 1,
+        "start_col_offset_idx": 2,
+        "end_col_offset_idx": 3,
+        "column_header": true,
+        "row_header": false,
+        "row_section": false
+      },
+      {
+        "text": "Widget A",
+        "bbox": null,
+        "row_span": 2,
+        "col_span": 1,
+        "start_row_offset_idx": 1,
+        "end_row_offset_idx": 3,
+        "start_col_offset_idx": 0,
+        "end_col_offset_idx": 1,
+        "column_header": false,
+        "row_header": false,
+        "row_section": false
+      },
+      {
+        "text": "1200",
+        "bbox": null,
+        "row_span": 1,
+        "col_span": 1,
+        "start_row_offset_idx": 1,
+        "end_row_offset_idx": 2,
+        "start_col_offset_idx": 1,
+        "end_col_offset_idx": 2,
+        "column_header": false,
+        "row_header": false,
+        "row_section": false
+      },
+      {
+        "text": "1500",
+        "bbox": null,
+        "row_span": 1,
+        "col_span": 1,
+        "start_row_offset_idx": 1,
+        "end_row_offset_idx": 2,
+        "start_col_offset_idx": 2,
+        "end_col_offset_idx": 3,
+        "column_header": false,
+        "row_header": false,
+        "row_section": false
+      },
+      {
+        "text": "950",
+        "bbox": null,
+        "row_span": 1,
+        "col_span": 2,
+        "start_row_offset_idx": 2,
+        "end_row_offset_idx": 3,
+        "start_col_offset_idx": 1,
+        "end_col_offset_idx": 3,
+        "column_header": false,
+        "row_header": false,
+        "row_section": false
+      }
+    ],
+    "num_rows": 3,
+    "num_cols": 3,
+    "grid": [
+      [
+        {
+          "text": "Product",
+          "bbox": null,
+          "row_span": 1,
+          "col_span": 1,
+          "start_row_offset_idx": 0,
+          "end_row_offset_idx": 1,
+          "start_col_offset_idx": 0,
+          "end_col_offset_idx": 1,
+          "column_header": true,
+          "row_header": false,
+          "row_section": false
+        },
+        {
+          "text": "Q1 Revenue",
+          "bbox": null,
+          "row_span": 1,
+          "col_span": 1,
+          "start_row_offset_idx": 0,
+          "end_row_offset_idx": 1,
+          "start_col_offset_idx": 1,
+          "end_col_offset_idx": 2,
+          "column_header": true,
+          "row_header": false,
+          "row_section": false
+        },
+        {
+          "text": "Q2 Revenue",
+          "bbox": null,
+          "row_span": 1,
+          "col_span": 1,
+          "start_row_offset_idx": 0,
+          "end_row_offset_idx": 1,
+          "start_col_offset_idx": 2,
+          "end_col_offset_idx": 3,
+          "column_header": true,
+          "row_header": false,
+          "row_section": false
+        }
+      ],
+      [
+        {
+          "text": "Widget A",
+          "bbox": null,
+          "row_span": 2,
+          "col_span": 1,
+          "start_row_offset_idx": 1,
+          "end_row_offset_idx": 3,
+          "start_col_offset_idx": 0,
+          "end_col_offset_idx": 1,
+          "column_header": false,
+          "row_header": false,
+          "row_section": false
+        },
+        {
+          "text": "1200",
+          "bbox": null,
+          "row_span": 1,
+          "col_span": 1,
+          "start_row_offset_idx": 1,
+          "end_row_offset_idx": 2,
+          "start_col_offset_idx": 1,
+          "end_col_offset_idx": 2,
+          "column_header": false,
+          "row_header": false,
+          "row_section": false
+        },
+        {
+          "text": "1500",
+          "bbox": null,
+          "row_span": 1,
+          "col_span": 1,
+          "start_row_offset_idx": 1,
+          "end_row_offset_idx": 2,
+          "start_col_offset_idx": 2,
+          "end_col_offset_idx": 3,
+          "column_header": false,
+          "row_header": false,
+          "row_section": false
+        }
+      ],
+      [
+        {
+          "text": "Widget A",
+          "bbox": null,
+          "row_span": 2,
+          "col_span": 1,
+          "start_row_offset_idx": 1,
+          "end_row_offset_idx": 3,
+          "start_col_offset_idx": 0,
+          "end_col_offset_idx": 1,
+          "column_header": false,
+          "row_header": false,
+          "row_section": false
+        },
+        {
+          "text": "950",
+          "bbox": null,
+          "row_span": 1,
+          "col_span": 2,
+          "start_row_offset_idx": 2,
+          "end_row_offset_idx": 3,
+          "start_col_offset_idx": 1,
+          "end_col_offset_idx": 3,
+          "column_header": false,
+          "row_header": false,
+          "row_section": false
+        },
+        {
+          "text": "950",
+          "bbox": null,
+          "row_span": 1,
+          "col_span": 2,
+          "start_row_offset_idx": 2,
+          "end_row_offset_idx": 3,
+          "start_col_offset_idx": 1,
+          "end_col_offset_idx": 3,
+          "column_header": false,
+          "row_header": false,
+          "row_section": false
+        }
+      ]
+    ]
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,8 @@ export type { NormalizeTableOptions } from "./normalize/normalize-table";
 export { normalizeTable } from "./normalize/normalize-table";
 export type { FlatArrayAdapterOptions } from "./adapters/from-flat-array";
 export { normalizeFromFlatArray } from "./adapters/from-flat-array";
+export type { NormalizeDoclingOptions } from "./adapters/from-docling";
+export { normalizeFromDocling } from "./adapters/from-docling";
 
 import { documentTableSchema } from "./schema/zod";
 import type { DocumentTable } from "./types/table";


### PR DESCRIPTION
## Summary
- Adds `normalizeFromDocling(tableItem, options?)` adapter that maps a Docling `TableItem` to `DocumentTable`
- Reads `data.grid` (2D cell array), deduplicates span-repeated cells using `start_row_offset_idx`/`start_col_offset_idx`, and maps `column_header`/`row_header` → `isHeader` + `rowType`
- Extracts page numbers from `prov[].page_no`; accepts `caption`, `title`, `tableId`, `sourceDocumentId` via options

## Changes
- `src/adapters/from-docling.ts` — new adapter (123 lines)
- `src/fixtures/adapters/docling-input.json` — realistic 3×3 Docling TableItem with header row, `row_span: 2`, and `col_span: 2`
- `src/__tests__/adapter-docling.test.ts` — 7 tests covering all acceptance criteria
- `src/index.ts` — exports `normalizeFromDocling` and `NormalizeDoclingOptions`

## Closes
Closes #19