### PR TITLE
feat: add normalizeFromMarker adapter

### DIFF
--- a/src/__tests__/adapter-marker.test.ts
+++ b/src/__tests__/adapter-marker.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import markerFixture from "../fixtures/adapters/marker-input.json";
+import { normalizeFromMarker, validateTable } from "../index";
+
+describe("normalizeFromMarker", () => {
+  it("fixture normalizes without throwing", () => {
+    expect(() => normalizeFromMarker(markerFixture)).not.toThrow();
+  });
+
+  it("result passes validateTable", () => {
+    const table = normalizeFromMarker(markerFixture);
+    expect(validateTable(table)).toBeTruthy();
+  });
+
+  it("header cells mapped correctly — isHeader true and rowType header", () => {
+    const table = normalizeFromMarker(markerFixture);
+    const headerRow = table.rows.find((r) => r.rowType === "header");
+    expect(headerRow).toBeDefined();
+    const cellMap = Object.fromEntries(table.cells.map((c) => [c.cellId, c]));
+    const headerCells = headerRow!.cellIds.map((id) => cellMap[id]);
+    expect(headerCells.every((c) => c?.isHeader === true)).toBe(true);
+    expect(headerCells.map((c) => c?.textRaw)).toEqual(["Product", "Q1 Revenue", "Q2 Revenue"]);
+  });
+
+  it("rowSpan and colSpan mapped from TableCell spans", () => {
+    const table = normalizeFromMarker(markerFixture);
+    const cellMap = Object.fromEntries(table.cells.map((c) => [c.cellId, c]));
+
+    const widgetACell = Object.values(cellMap).find(
+      (c) => c?.textRaw === "Widget A" && c.rowIndex === 1
+    );
+    expect(widgetACell).toBeDefined();
+    expect(widgetACell?.rowSpan).toBe(2);
+
+    const ninetyFiftyCell = Object.values(cellMap).find(
+      (c) => c?.textRaw === "950" && c.rowIndex === 2
+    );
+    expect(ninetyFiftyCell).toBeDefined();
+    expect(ninetyFiftyCell?.colSpan).toBe(2);
+  });
+
+  it("Markdown pipe-table string → normalizes + fidelityWarnings includes markdown-lossy", () => {
+    const markdown =
+      "| Product | Q1 | Q2 |\n|---|---|---|\n| Widget A | 100 | 200 |\n| Widget B | 300 | 400 |";
+    const table = normalizeFromMarker(markdown);
+    expect(validateTable(table)).toBeTruthy();
+    expect(table.fidelityWarnings).toContain("markdown-lossy");
+  });
+
+  it("invalid input throws", () => {
+    expect(() => normalizeFromMarker(null)).toThrow();
+    expect(() => normalizeFromMarker(42)).toThrow();
+    expect(() => normalizeFromMarker({})).toThrow();
+  });
+});

--- a/src/adapters/from-marker.ts
+++ b/src/adapters/from-marker.ts
@@ -1,0 +1,151 @@
+import { normalizeTable } from "../normalize/normalize-table";
+import type { NormalizeTableOptions } from "../normalize/normalize-table";
+import type { DocumentTable } from "../types/table";
+import { createId } from "../utils/ids";
+import { normalizeText } from "../utils/text";
+import { normalizeFromFlatArray } from "./from-flat-array";
+
+export type NormalizeMarkerOptions = NormalizeTableOptions & {
+  tableId?: string;
+  title?: string;
+  caption?: string;
+  sourceDocumentId?: string;
+  page?: number;
+};
+
+function parseMarkdownTable(markdown: string): string[][] {
+  const lines = markdown.split("\n").map((l) => l.trim()).filter(Boolean);
+  const dataLines = lines.filter((l) => !/^\|[-:| ]+\|$/.test(l));
+  return dataLines.map((line) =>
+    line.split("|").slice(1, -1).map((cell) => cell.trim())
+  );
+}
+
+export function normalizeFromMarker(
+  tableBlock: unknown,
+  options: NormalizeMarkerOptions = {}
+): DocumentTable {
+  if (typeof tableBlock === "string") {
+    const trimmed = tableBlock.trim();
+    if (!trimmed.startsWith("|")) {
+      throw new Error("normalizeFromMarker: string input must be a Markdown pipe table");
+    }
+    const rows = parseMarkdownTable(trimmed);
+    if (rows.length === 0) {
+      throw new Error("normalizeFromMarker: Markdown table has no rows");
+    }
+    const table = normalizeFromFlatArray(rows, {
+      tableId: options.tableId,
+      title: options.title,
+      pages: options.page !== undefined ? [options.page] : [1],
+      standardVersion: options.standardVersion,
+    });
+    const existing = table.fidelityWarnings ?? [];
+    return {
+      ...table,
+      fidelityWarnings: existing.includes("markdown-lossy")
+        ? existing
+        : [...existing, "markdown-lossy"],
+    };
+  }
+
+  if (tableBlock === null || typeof tableBlock !== "object" || Array.isArray(tableBlock)) {
+    throw new Error(
+      "normalizeFromMarker: tableBlock must be a non-null object or a Markdown pipe-table string"
+    );
+  }
+
+  const block = tableBlock as Record<string, unknown>;
+
+  if (typeof block["block_type"] === "string" && block["block_type"] !== "Table") {
+    throw new Error(
+      `normalizeFromMarker: expected block_type "Table", got "${block["block_type"]}"`
+    );
+  }
+
+  const children = Array.isArray(block["children"]) ? (block["children"] as unknown[]) : [];
+
+  if (children.length === 0) {
+    throw new Error("normalizeFromMarker: Table block has no children cells");
+  }
+
+  const tableId = options.tableId ?? createId("tbl");
+  const page = options.page ?? 1;
+
+  type RowEntry = { rowId: number; isHeader: boolean; cells: Record<string, unknown>[] };
+  const rowMap = new Map<number, RowEntry>();
+
+  for (const child of children) {
+    if (child === null || typeof child !== "object" || Array.isArray(child)) continue;
+    const c = child as Record<string, unknown>;
+    if (c["block_type"] !== "TableCell") continue;
+
+    const rowId = typeof c["row_id"] === "number" ? c["row_id"] : undefined;
+    const colId = typeof c["col_id"] === "number" ? c["col_id"] : undefined;
+    if (rowId === undefined || colId === undefined) continue;
+
+    const isHeader = c["is_header"] === true;
+    const rowspan = typeof c["rowspan"] === "number" && c["rowspan"] > 1 ? c["rowspan"] : undefined;
+    const colspan = typeof c["colspan"] === "number" && c["colspan"] > 1 ? c["colspan"] : undefined;
+
+    const textLines = Array.isArray(c["text_lines"]) ? (c["text_lines"] as unknown[]) : [];
+    const textRaw = textLines.map((l) => (typeof l === "string" ? l : "")).join("\n");
+
+    const cell: Record<string, unknown> = {
+      rowIndex: rowId,
+      colIndex: colId,
+      textRaw,
+      textNormalized: normalizeText(textRaw),
+      isHeader,
+    };
+    if (rowspan !== undefined) cell["rowSpan"] = rowspan;
+    if (colspan !== undefined) cell["colSpan"] = colspan;
+
+    const row: RowEntry = rowMap.get(rowId) ?? { rowId, isHeader: false, cells: [] };
+    if (isHeader) row.isHeader = true;
+    row.cells.push(cell);
+    rowMap.set(rowId, row);
+  }
+
+  if (rowMap.size === 0) {
+    throw new Error("normalizeFromMarker: no valid TableCell children found");
+  }
+
+  const sortedRowIds = [...rowMap.keys()].sort((a, b) => a - b);
+  const allCells: Record<string, unknown>[] = [];
+  const rowObjects: unknown[] = [];
+
+  for (const rowId of sortedRowIds) {
+    const row = rowMap.get(rowId)!;
+    const sorted = row.cells.slice().sort(
+      (a, b) => (a["colIndex"] as number) - (b["colIndex"] as number)
+    );
+    allCells.push(...sorted);
+    rowObjects.push({ rowIndex: rowId, rowType: row.isHeader ? "header" : "body", page });
+  }
+
+  const numCols = allCells.reduce((max, cell) => {
+    const col = (cell["colIndex"] as number) ?? 0;
+    const span = typeof cell["colSpan"] === "number" ? cell["colSpan"] : 1;
+    return Math.max(max, col + span);
+  }, 0);
+
+  const columns = Array.from({ length: numCols }, (_, i) => ({ colIndex: i }));
+
+  const raw: Record<string, unknown> = {
+    tableId,
+    pages: [page],
+    columns,
+    rows: rowObjects,
+    cells: allCells,
+  };
+
+  if (options.caption !== undefined) raw["caption"] = options.caption;
+  if (options.title !== undefined) raw["title"] = options.title;
+  if (options.sourceDocumentId !== undefined) raw["sourceDocumentId"] = options.sourceDocumentId;
+
+  return normalizeTable(raw, {
+    standardVersion: options.standardVersion,
+    inferHeaders: options.inferHeaders,
+  });
+}

--- a/src/fixtures/adapters/marker-input.json
+++ b/src/fixtures/adapters/marker-input.json
@@ -1,0 +1,101 @@
+{
+  "id": "/page/1/Table/0",
+  "block_type": "Table",
+  "html": "<table><tr><th>Product</th><th>Q1 Revenue</th><th>Q2 Revenue</th></tr><tr><td rowspan=\"2\">Widget A</td><td>100</td><td>200</td></tr><tr><td colspan=\"2\">950</td></tr></table>",
+  "polygon": [[72.0, 150.0], [540.0, 150.0], [540.0, 400.0], [72.0, 400.0]],
+  "bbox": [72.0, 150.0, 468.0, 250.0],
+  "section_hierarchy": { "1": "Financial Results" },
+  "children": [
+    {
+      "id": "/page/1/TableCell/0",
+      "block_type": "TableCell",
+      "html": "<th>Product</th>",
+      "polygon": [[72.0, 150.0], [200.0, 150.0], [200.0, 175.0], [72.0, 175.0]],
+      "bbox": [72.0, 150.0, 128.0, 25.0],
+      "row_id": 0,
+      "col_id": 0,
+      "rowspan": 1,
+      "colspan": 1,
+      "is_header": true,
+      "text_lines": ["Product"]
+    },
+    {
+      "id": "/page/1/TableCell/1",
+      "block_type": "TableCell",
+      "html": "<th>Q1 Revenue</th>",
+      "polygon": [[200.0, 150.0], [370.0, 150.0], [370.0, 175.0], [200.0, 175.0]],
+      "bbox": [200.0, 150.0, 170.0, 25.0],
+      "row_id": 0,
+      "col_id": 1,
+      "rowspan": 1,
+      "colspan": 1,
+      "is_header": true,
+      "text_lines": ["Q1 Revenue"]
+    },
+    {
+      "id": "/page/1/TableCell/2",
+      "block_type": "TableCell",
+      "html": "<th>Q2 Revenue</th>",
+      "polygon": [[370.0, 150.0], [540.0, 150.0], [540.0, 175.0], [370.0, 175.0]],
+      "bbox": [370.0, 150.0, 170.0, 25.0],
+      "row_id": 0,
+      "col_id": 2,
+      "rowspan": 1,
+      "colspan": 1,
+      "is_header": true,
+      "text_lines": ["Q2 Revenue"]
+    },
+    {
+      "id": "/page/1/TableCell/3",
+      "block_type": "TableCell",
+      "html": "<td rowspan=\"2\">Widget A</td>",
+      "polygon": [[72.0, 175.0], [200.0, 175.0], [200.0, 225.0], [72.0, 225.0]],
+      "bbox": [72.0, 175.0, 128.0, 50.0],
+      "row_id": 1,
+      "col_id": 0,
+      "rowspan": 2,
+      "colspan": 1,
+      "is_header": false,
+      "text_lines": ["Widget A"]
+    },
+    {
+      "id": "/page/1/TableCell/4",
+      "block_type": "TableCell",
+      "html": "<td>100</td>",
+      "polygon": [[200.0, 175.0], [370.0, 175.0], [370.0, 200.0], [200.0, 200.0]],
+      "bbox": [200.0, 175.0, 170.0, 25.0],
+      "row_id": 1,
+      "col_id": 1,
+      "rowspan": 1,
+      "colspan": 1,
+      "is_header": false,
+      "text_lines": ["100"]
+    },
+    {
+      "id": "/page/1/TableCell/5",
+      "block_type": "TableCell",
+      "html": "<td>200</td>",
+      "polygon": [[370.0, 175.0], [540.0, 175.0], [540.0, 200.0], [370.0, 200.0]],
+      "bbox": [370.0, 175.0, 170.0, 25.0],
+      "row_id": 1,
+      "col_id": 2,
+      "rowspan": 1,
+      "colspan": 1,
+      "is_header": false,
+      "text_lines": ["200"]
+    },
+    {
+      "id": "/page/1/TableCell/6",
+      "block_type": "TableCell",
+      "html": "<td colspan=\"2\">950</td>",
+      "polygon": [[200.0, 200.0], [540.0, 200.0], [540.0, 225.0], [200.0, 225.0]],
+      "bbox": [200.0, 200.0, 340.0, 25.0],
+      "row_id": 2,
+      "col_id": 1,
+      "rowspan": 1,
+      "colspan": 2,
+      "is_header": false,
+      "text_lines": ["950"]
+    }
+  ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,8 @@ export type { FlatArrayAdapterOptions } from "./adapters/from-flat-array";
 export { normalizeFromFlatArray } from "./adapters/from-flat-array";
 export type { NormalizeDoclingOptions } from "./adapters/from-docling";
 export { normalizeFromDocling } from "./adapters/from-docling";
+export type { NormalizeMarkerOptions } from "./adapters/from-marker";
+export { normalizeFromMarker } from "./adapters/from-marker";
 
 import { documentTableSchema } from "./schema/zod";
 import type { DocumentTable } from "./types/table";


### PR DESCRIPTION
## Summary

Adds a `normalizeFromMarker` adapter that converts [VikParuchuri/marker](https://github.com/VikParuchuri/marker) JSON table blocks into the canonical `DocumentTable` format. Handles both Marker's structured `TableCell`-based JSON output and a Markdown pipe-table string fallback.

## Changes

- `src/adapters/from-marker.ts` — new adapter; maps `row_id`/`col_id`/`is_header`/`rowspan`/`colspan`/`text_lines` fields from Marker's `TableCell` children; string pipe-table input delegates to `normalizeFromFlatArray` then stamps `fidelityWarnings: ["markdown-lossy"]`
- `src/fixtures/adapters/marker-input.json` — realistic Marker JSON block fixture with header row, `rowspan: 2`, and `colspan: 2` cells
- `src/__tests__/adapter-marker.test.ts` — 6 tests: fixture round-trip, `validateTable`, header mapping, span fields, Markdown fallback + `markdown-lossy` warning, invalid input throws
- `src/index.ts` — exports `normalizeFromMarker` and `NormalizeMarkerOptions`

## Closes

Closes #20