### PR TITLE
feat: add tpds CLI tool (validate, normalize, export)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: npm run build
       - run: npm test
 
   build:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "tpds": "./dist/cli.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,0 +1,156 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const cliBin = path.join(rootDir, "dist", "cli.js");
+const fixturesDir = path.join(rootDir, "src", "fixtures");
+const simpleFixture = path.join(fixturesDir, "simple-table.json");
+
+const invalidJsonPath = path.join(tmpdir(), "tpds-test-invalid.json");
+const invalidTablePath = path.join(tmpdir(), "tpds-test-invalid-table.json");
+
+const run = (...args: string[]) =>
+  spawnSync(process.execPath, [cliBin, ...args], { encoding: "utf8" });
+
+beforeAll(() => {
+  writeFileSync(invalidJsonPath, "not valid json", "utf8");
+  writeFileSync(invalidTablePath, JSON.stringify({ foo: "bar" }), "utf8");
+});
+
+afterAll(() => {
+  if (existsSync(invalidJsonPath)) unlinkSync(invalidJsonPath);
+  if (existsSync(invalidTablePath)) unlinkSync(invalidTablePath);
+});
+
+describe("tpds CLI binary", () => {
+  it("dist/cli.js exists after build", () => {
+    expect(existsSync(cliBin)).toBe(true);
+  });
+
+  describe("--help", () => {
+    it("exits 0 and lists all commands", () => {
+      const result = run("--help");
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("validate");
+      expect(result.stdout).toContain("normalize");
+      expect(result.stdout).toContain("export");
+    });
+  });
+
+  describe("validate", () => {
+    it("exits 0 for a valid fixture", () => {
+      const result = run("validate", simpleFixture);
+      expect(result.status).toBe(0);
+    });
+
+    it("exits 1 and prints error for invalid JSON file", () => {
+      const result = run("validate", invalidJsonPath);
+      expect(result.status).toBe(1);
+    });
+
+    it("exits 1 and prints error for JSON that fails schema", () => {
+      const result = run("validate", invalidTablePath);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBeTruthy();
+    });
+
+    it("exits 1 when file does not exist", () => {
+      const result = run("validate", "/tmp/tpds-no-such-file.json");
+      expect(result.status).toBe(1);
+    });
+
+    it("shows validate help with --help", () => {
+      const result = run("validate", "--help");
+      expect(result.status).toBe(0);
+    });
+  });
+
+  describe("normalize", () => {
+    it("outputs valid canonical JSON to stdout", () => {
+      const result = run("normalize", simpleFixture);
+      expect(result.status).toBe(0);
+      const parsed: unknown = JSON.parse(result.stdout);
+      expect(parsed).toHaveProperty("tableId");
+      expect(parsed).toHaveProperty("cells");
+      expect(parsed).toHaveProperty("rows");
+    });
+
+    it("writes JSON to --output file", () => {
+      const outPath = path.join(tmpdir(), "tpds-normalize-out.json");
+      try {
+        const result = run("normalize", simpleFixture, "--output", outPath);
+        expect(result.status).toBe(0);
+        expect(existsSync(outPath)).toBe(true);
+        const parsed: unknown = JSON.parse(readFileSync(outPath, "utf8"));
+        expect(parsed).toHaveProperty("tableId");
+      } finally {
+        if (existsSync(outPath)) unlinkSync(outPath);
+      }
+    });
+
+    it("exits 1 when file does not exist", () => {
+      const result = run("normalize", "/tmp/tpds-no-such-file.json");
+      expect(result.status).toBe(1);
+    });
+  });
+
+  describe("export", () => {
+    it("outputs HTML for --format html", () => {
+      const result = run("export", simpleFixture, "--format", "html");
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("<table>");
+      expect(result.stdout).toContain("</table>");
+    });
+
+    it("outputs markdown for --format markdown", () => {
+      const result = run("export", simpleFixture, "--format", "markdown");
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("|");
+    });
+
+    it("outputs JSON string for --format json", () => {
+      const result = run("export", simpleFixture, "--format", "json");
+      expect(result.status).toBe(0);
+      const parsed: unknown = JSON.parse(result.stdout);
+      expect(parsed).toHaveProperty("tableId");
+    });
+
+    it("writes HTML to --output file", () => {
+      const outPath = path.join(tmpdir(), "tpds-export-out.html");
+      try {
+        const result = run("export", simpleFixture, "--format", "html", "--output", outPath);
+        expect(result.status).toBe(0);
+        expect(existsSync(outPath)).toBe(true);
+      } finally {
+        if (existsSync(outPath)) unlinkSync(outPath);
+      }
+    });
+
+    it("exits 1 when --format is missing", () => {
+      const result = run("export", simpleFixture);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("--format");
+    });
+
+    it("exits 1 for unknown --format value", () => {
+      const result = run("export", simpleFixture, "--format", "pdf");
+      expect(result.status).toBe(1);
+    });
+
+    it("exits 1 when file does not exist", () => {
+      const result = run("export", "/tmp/tpds-no-such-file.json", "--format", "html");
+      expect(result.status).toBe(1);
+    });
+  });
+
+  describe("unknown command", () => {
+    it("exits 1 for an unknown command", () => {
+      const result = run("foobar");
+      expect(result.status).toBe(1);
+    });
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,192 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  safeValidateTable,
+  validateTable,
+  normalizeTable,
+  tableToHtml,
+  tableToJson,
+  tableToMarkdown,
+} from "./index.js";
+
+const USAGE = `Usage: tpds <command> [options]
+
+Commands:
+  validate <file.json>
+      Validate a DocumentTable JSON file against the schema.
+      Exits 0 if valid, exits 1 with error details if not.
+
+  normalize <file.json> [--output <out.json>]
+      Normalize input to canonical JSON. Writes to --output or stdout.
+
+  export <file.json> --format html|markdown|json [--output <file>]
+      Export a canonical DocumentTable. Writes to --output or stdout.
+
+Options:
+  --help    Show this help message
+`;
+
+const VALIDATE_USAGE = `Usage: tpds validate <file.json>
+
+Validates a DocumentTable JSON file. Exits 0 if valid, 1 if not.
+`;
+
+const NORMALIZE_USAGE = `Usage: tpds normalize <file.json> [--output <out.json>]
+
+Normalizes input to canonical DocumentTable JSON.
+`;
+
+const EXPORT_USAGE = `Usage: tpds export <file.json> --format html|markdown|json [--output <file>]
+
+  --format   Required. One of: html, markdown, json
+  --output   Optional. Write to this file instead of stdout.
+`;
+
+type ParsedArgs = {
+  positional: string[];
+  flags: Map<string, string | true>;
+};
+
+function parseArgs(args: string[]): ParsedArgs {
+  const positional: string[] = [];
+  const flags = new Map<string, string | true>();
+  const VALUE_FLAGS = new Set(["--output", "--format"]);
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+    if (arg === undefined) break;
+    if (VALUE_FLAGS.has(arg)) {
+      flags.set(arg, args[i + 1] ?? "");
+      i += 2;
+    } else if (arg.startsWith("-")) {
+      flags.set(arg, true);
+      i++;
+    } else {
+      positional.push(arg);
+      i++;
+    }
+  }
+  return { positional, flags };
+}
+
+function readJson(filePath: string): unknown {
+  let raw: string;
+  try {
+    raw = readFileSync(resolve(filePath), "utf8");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Error reading file "${filePath}": ${msg}\n`);
+    process.exit(1);
+  }
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Error parsing JSON in "${filePath}": ${msg}\n`);
+    process.exit(1);
+  }
+}
+
+function writeOutput(content: string, outputPath: string | undefined): void {
+  if (outputPath) {
+    writeFileSync(resolve(outputPath), content, "utf8");
+  } else {
+    process.stdout.write(content);
+    if (!content.endsWith("\n")) process.stdout.write("\n");
+  }
+}
+
+const argv = process.argv.slice(2);
+
+if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h") {
+  process.stdout.write(USAGE);
+  process.exit(0);
+}
+
+const command = argv[0];
+const { positional, flags } = parseArgs(argv.slice(1));
+const isHelp = flags.has("--help") || flags.has("-h");
+
+if (command === "validate") {
+  if (isHelp) {
+    process.stdout.write(VALIDATE_USAGE);
+    process.exit(0);
+  }
+  const filePath = positional[0];
+  if (!filePath) {
+    process.stderr.write("Error: validate requires a file path\n");
+    process.exit(1);
+  }
+  const data = readJson(filePath);
+  const result = safeValidateTable(data);
+  if (result.success) {
+    process.stdout.write(`Valid: ${filePath}\n`);
+    process.exit(0);
+  } else {
+    process.stderr.write(`Invalid: ${filePath}\n`);
+    process.stderr.write(result.error.toString() + "\n");
+    process.exit(1);
+  }
+} else if (command === "normalize") {
+  if (isHelp) {
+    process.stdout.write(NORMALIZE_USAGE);
+    process.exit(0);
+  }
+  const filePath = positional[0];
+  if (!filePath) {
+    process.stderr.write("Error: normalize requires a file path\n");
+    process.exit(1);
+  }
+  const data = readJson(filePath);
+  const outputPath = flags.get("--output") as string | undefined;
+  try {
+    const table = normalizeTable(data);
+    writeOutput(tableToJson(table), outputPath);
+    process.exit(0);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Normalization failed: ${msg}\n`);
+    process.exit(1);
+  }
+} else if (command === "export") {
+  if (isHelp) {
+    process.stdout.write(EXPORT_USAGE);
+    process.exit(0);
+  }
+  const filePath = positional[0];
+  if (!filePath) {
+    process.stderr.write("Error: export requires a file path\n");
+    process.exit(1);
+  }
+  const format = flags.get("--format") as string | undefined;
+  if (!format || !["html", "markdown", "json"].includes(format)) {
+    process.stderr.write(
+      `Error: --format must be one of: html, markdown, json${format ? ` (got "${format}")` : ""}\n`
+    );
+    process.exit(1);
+  }
+  const data = readJson(filePath);
+  let table;
+  try {
+    table = validateTable(data);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Invalid DocumentTable: ${msg}\n`);
+    process.exit(1);
+  }
+  const outputPath = flags.get("--output") as string | undefined;
+  let output: string;
+  if (format === "html") {
+    output = tableToHtml(table);
+  } else if (format === "markdown") {
+    output = tableToMarkdown(table).markdown;
+  } else {
+    output = tableToJson(table);
+  }
+  writeOutput(output, outputPath);
+  process.exit(0);
+} else {
+  process.stderr.write(`Unknown command: "${command}"\n\n`);
+  process.stdout.write(USAGE);
+  process.exit(1);
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,15 +1,25 @@
 import { copyFileSync } from "fs";
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-  entry: ["src/index.ts"],
-  format: ["esm", "cjs"],
-  dts: true,
-  sourcemap: true,
-  clean: true,
-  target: "node18",
-  onSuccess: async () => {
-    copyFileSync("src/schema/json-schema.json", "dist/schema.json");
-    console.log("Copied src/schema/json-schema.json → dist/schema.json");
-  }
-});
+export default defineConfig([
+  {
+    entry: ["src/index.ts"],
+    format: ["esm", "cjs"],
+    dts: true,
+    sourcemap: true,
+    clean: true,
+    target: "node18",
+    onSuccess: async () => {
+      copyFileSync("src/schema/json-schema.json", "dist/schema.json");
+      console.log("Copied src/schema/json-schema.json → dist/schema.json");
+    },
+  },
+  {
+    entry: ["src/cli.ts"],
+    format: ["esm"],
+    dts: false,
+    sourcemap: false,
+    target: "node18",
+    banner: { js: "#!/usr/bin/env node" },
+  },
+]);


### PR DESCRIPTION
## Summary

- Adds `src/cli.ts` — a Node.js CLI with three subcommands: `validate`, `normalize`, and `export`
- No new runtime dependencies; uses only Node.js built-ins (`fs`, `process`)
- `dist/cli.js` is the compiled binary registered as `"tpds"` via `package.json` `bin` field

## Changes

- **`src/cli.ts`** — CLI entry point with a hand-rolled arg parser; handles `validate <file>`, `normalize <file> [--output]`, `export <file> --format html|markdown|json [--output]`, and `--help` / per-command `--help`
- **`src/__tests__/cli.test.ts`** — 18 tests that spawn the compiled binary with fixture inputs; covers all commands, `--output` file writes, invalid input, missing flags, and unknown commands
- **`tsup.config.ts`** — converted to array config; CLI entry builds ESM-only with no DTS and a `#!/usr/bin/env node` shebang banner
- **`package.json`** — adds `"bin": { "tpds": "./dist/cli.js" }`

Test count: **96 → 114** (all passing).

## Closes

Closes #21