### PR TITLE
Fix mergeMultiPageTables fallback for untitled tables

### DIFF
--- a/src/__tests__/merge-multipage.test.ts
+++ b/src/__tests__/merge-multipage.test.ts
@@ -113,6 +113,23 @@ describe("mergeMultiPageTables", () => {
     expect(result).toHaveLength(2);
   });
 
+  it("does not merge unrelated untitled tables that only share document and columns", () => {
+    const page1 = makeTable("untitled-1", "doc-h", "", [1], {
+      title: undefined,
+      caption: undefined,
+      columns: [{ colIndex: 0 }, { colIndex: 1 }],
+    });
+    const page2 = makeTable("untitled-2", "doc-h", "", [2], {
+      title: undefined,
+      caption: undefined,
+      columns: [{ colIndex: 0 }, { colIndex: 1 }],
+    });
+
+    const result = mergeMultiPageTables([page1, page2]);
+
+    expect(result).toHaveLength(2);
+  });
+
   it("does not merge title-matching tables when mergeByTitle is false", () => {
     const t1 = makeTable("opt-1", "doc-g", "Summary", [1]);
     const t2 = makeTable("opt-2", "doc-g", "Summary", [2]);

--- a/src/normalize/merge-multipage.ts
+++ b/src/normalize/merge-multipage.ts
@@ -14,7 +14,14 @@ const mergeKey = (table: DocumentTable, options: MergeMultiPageTablesOptions): s
   }
 
   const docId = table.sourceDocumentId ?? "unknown-doc";
-  const title = options.mergeByTitle === false ? table.tableId : normalizeText(table.title ?? table.caption ?? "");
+  const title = options.mergeByTitle === false
+    ? ""
+    : normalizeText(table.title ?? "") || normalizeText(table.caption ?? "");
+
+  if (!title) {
+    return `${docId}:${table.tableId}`;
+  }
+
   const columns = table.columns.map((column) => normalizeText(column.label ?? String(column.colIndex))).join("|");
   return `${docId}:${title}:${columns}`;
 };


### PR DESCRIPTION
## Summary

Prevent `mergeMultiPageTables()` from merging unrelated untitled tables that only share a source document and column layout.

## Changes

- fall back to `tableId` when no non-empty title or caption is available for merge-key generation
- prefer a non-empty normalized `caption` when `title` is missing or empty
- add a regression test covering two untitled tables in the same document with identical columns
- verified with `npm run lint`, `npm test`, and `npm run build`

## Closes

Closes #57