### PR TITLE
Fix row chunk builders including footer rows

### DIFF
--- a/src/__tests__/chunking.test.ts
+++ b/src/__tests__/chunking.test.ts
@@ -5,6 +5,7 @@ import {
   buildRowChunks,
   buildRowGroupChunks,
   buildTableChunks,
+  type DocumentTable,
   inferHeaders,
   mergeMultiPageTables,
 } from "../index";
@@ -92,6 +93,34 @@ describe("chunk builders", () => {
     expect(rowIndexes).not.toContain(0);
     expect(rowIndexes).not.toContain(2);
     expect(rowIndexes).toEqual(expect.arrayContaining([1, 3]));
+  });
+
+  it("row chunk builders skip footer rows", () => {
+    const table = {
+      standardVersion: "1.0.0",
+      tableId: "t1",
+      pages: [1],
+      columns: [
+        { colIndex: 0, label: "Item" },
+        { colIndex: 1, label: "Value" },
+      ],
+      rows: [
+        { rowIndex: 0, rowType: "header", cellIds: ["h0", "h1"], page: 1 },
+        { rowIndex: 1, rowType: "body", cellIds: ["b0", "b1"], page: 1 },
+        { rowIndex: 2, rowType: "footer", cellIds: ["f0", "f1"], page: 1 },
+      ],
+      cells: [
+        { cellId: "h0", rowIndex: 0, colIndex: 0, textRaw: "Item", textNormalized: "Item", isHeader: true, page: 1 },
+        { cellId: "h1", rowIndex: 0, colIndex: 1, textRaw: "Value", textNormalized: "Value", isHeader: true, page: 1 },
+        { cellId: "b0", rowIndex: 1, colIndex: 0, textRaw: "Revenue", textNormalized: "Revenue", page: 1 },
+        { cellId: "b1", rowIndex: 1, colIndex: 1, textRaw: "100", textNormalized: "100", page: 1 },
+        { cellId: "f0", rowIndex: 2, colIndex: 0, textRaw: "Total", textNormalized: "Total", isHeader: true, page: 1 },
+        { cellId: "f1", rowIndex: 2, colIndex: 1, textRaw: "100", textNormalized: "100", page: 1 },
+      ],
+    } satisfies DocumentTable;
+
+    expect(buildRowChunks(table).map((chunk) => chunk.rowIndexes)).toEqual([[1]]);
+    expect(buildRowGroupChunks(table, 5).map((chunk) => chunk.rowIndexes)).toEqual([[1]]);
   });
 
   it("buildRowGroupChunks produces ceil(bodyRows/groupSize) chunks with correct rowIndexes", () => {

--- a/src/chunk/build-row-chunks.ts
+++ b/src/chunk/build-row-chunks.ts
@@ -51,7 +51,7 @@ export const buildRowChunks = (
   options: BuildRowChunksOptions = {}
 ): TableChunk[] =>
   sortRows(table.rows)
-    .filter((row) => row.rowType !== "header" && row.rowType !== "note")
+    .filter((row) => row.rowType !== "header" && row.rowType !== "footer" && row.rowType !== "note")
     .filter((row) => options.includeRepeatedHeaders || !row.repeatedHeaderRow)
     .map((row) => {
       const serialized = serializeRow(table, row.rowIndex);

--- a/src/chunk/build-table-chunks.ts
+++ b/src/chunk/build-table-chunks.ts
@@ -14,6 +14,7 @@ export const buildRowGroupChunks = (
   const targetRows = sortRows(table.rows).filter(
     (row) =>
       row.rowType !== "header" &&
+      row.rowType !== "footer" &&
       row.rowType !== "note" &&
       (includeRepeatedHeaders || !row.repeatedHeaderRow)
   );


### PR DESCRIPTION
## Summary

Fix the row chunk builders so footer rows are no longer emitted as normal row or row-group chunks. This restores the documented body-row-only contract for chunking APIs without changing other chunk behavior.

## Changes

- exclude `footer` rows in `buildRowChunks`
- exclude `footer` rows in `buildRowGroupChunks`
- add a regression test covering a header/body/footer table and asserting only the body row is chunked
- verify the issue repro now returns only body-row chunk indexes after rebuilding

## Closes

Closes #58