### PR TITLE
docs: finalize 0.1.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - Unreleased
+## [0.1.0] - 2026-04-19
 
 ### Added
 


### PR DESCRIPTION
## Summary
- change the 0.1.0 changelog entry from placeholder status to the release date
- prepare the repo for the initial npm release tag

Closes #59