### PR TITLE
test: build cli fixture on clean checkout

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -9,6 +9,7 @@ const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../.
 const cliBin = path.join(rootDir, "dist", "cli.js");
 const fixturesDir = path.join(rootDir, "src", "fixtures");
 const simpleFixture = path.join(fixturesDir, "simple-table.json");
+const npmBin = process.platform === "win32" ? "npm.cmd" : "npm";
 
 const invalidJsonPath = path.join(tmpdir(), "tpds-test-invalid.json");
 const invalidTablePath = path.join(tmpdir(), "tpds-test-invalid-table.json");
@@ -19,6 +20,18 @@ const run = (...args: string[]) =>
 beforeAll(() => {
   writeFileSync(invalidJsonPath, "not valid json", "utf8");
   writeFileSync(invalidTablePath, JSON.stringify({ foo: "bar" }), "utf8");
+  if (!existsSync(cliBin)) {
+    const build = spawnSync(npmBin, ["run", "build"], {
+      cwd: rootDir,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    if (build.status !== 0) {
+      throw new Error(
+        `Failed to build CLI test fixture.\nstdout:\n${build.stdout}\nstderr:\n${build.stderr}`
+      );
+    }
+  }
 });
 
 afterAll(() => {


### PR DESCRIPTION
## Summary
- build the CLI artifact in cli tests when dist/cli.js is missing
- make npm test pass from a clean checkout and in the publish workflow

## Why
The v0.1.0 publish workflow failed because cli tests expected dist/cli.js before npm run build had executed in a clean checkout.

Closes #59