### PR TITLE
fix: preserve cli bin entry for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "tpds": "./dist/cli.js"
+    "tpds": "dist/cli.js"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- normalize the published CLI bin path to dist/cli.js
- align package metadata with npm's package fixer before release

## Why
The publish workflow reached npm but logged that the bin entry would be auto-corrected and removed.

Closes #59