### PR TITLE
[codex] add real-world eval workflow

### DIFF
--- a/docs/real-world-eval.md
+++ b/docs/real-world-eval.md
@@ -41,6 +41,42 @@ EPSCA resources pages on April 19, 2026:
 This is intentionally a starter corpus, not the full EPSCA universe. The goal
 is to decide whether TPDS is safe to publish first, then expand coverage later.
 
+## How to run it now
+
+TPDS still does not extract tables from PDFs by itself. The intended flow is:
+
+1. run your upstream extractor on one EPSCA PDF and save the extractor JSON
+2. feed that JSON into `tpds eval` with the matching adapter
+3. review the generated artifacts and complete the rubric in the generated
+   `report.md`
+
+Example using a Docling-shaped JSON export:
+
+```bash
+npm run build
+node dist/cli.js eval /path/to/docling-table.json \
+  --adapter docling \
+  --output-dir docs/evals/epsca-wage-reference-guide \
+  --pdf-title "Wage Schedule Reference Guide.pdf" \
+  --source-url "https://www.epsca.org/wage-schedules" \
+  --access-date 2026-04-19 \
+  --evaluator "Your Name" \
+  --extractor "docling" \
+  --extractor-command "docling pipeline revision or command here"
+```
+
+That writes:
+
+- `normalized.json`
+- `export.html`
+- `export.md`
+- `export.markdown.json`
+- `chunks.json`
+- `report.md`
+
+Checking the finished bundle into `docs/evals/...` satisfies the release-gate
+requirement that at least one evaluation summary lives under `docs/`.
+
 ## What TPDS currently preserves well
 
 - Header grouping survives in canonical JSON through `headerGroups` and

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -13,6 +13,7 @@ const npmBin = process.platform === "win32" ? "npm.cmd" : "npm";
 
 const invalidJsonPath = path.join(tmpdir(), "tpds-test-invalid.json");
 const invalidTablePath = path.join(tmpdir(), "tpds-test-invalid-table.json");
+const evalOutDir = path.join(tmpdir(), "tpds-eval-out");
 
 const run = (...args: string[]) =>
   spawnSync(process.execPath, [cliBin, ...args], { encoding: "utf8", stdio: "pipe" });
@@ -20,23 +21,22 @@ const run = (...args: string[]) =>
 beforeAll(() => {
   writeFileSync(invalidJsonPath, "not valid json", "utf8");
   writeFileSync(invalidTablePath, JSON.stringify({ foo: "bar" }), "utf8");
-  if (!existsSync(cliBin)) {
-    const build = spawnSync(npmBin, ["run", "build"], {
-      cwd: rootDir,
-      encoding: "utf8",
-      stdio: "pipe",
-    });
-    if (build.status !== 0) {
-      throw new Error(
-        `Failed to build CLI test fixture.\nstdout:\n${build.stdout}\nstderr:\n${build.stderr}`
-      );
-    }
+  const build = spawnSync(npmBin, ["run", "build"], {
+    cwd: rootDir,
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+  if (build.status !== 0) {
+    throw new Error(
+      `Failed to build CLI test fixture.\nstdout:\n${build.stdout}\nstderr:\n${build.stderr}`
+    );
   }
 });
 
 afterAll(() => {
   if (existsSync(invalidJsonPath)) unlinkSync(invalidJsonPath);
   if (existsSync(invalidTablePath)) unlinkSync(invalidTablePath);
+  if (existsSync(evalOutDir)) rmSync(evalOutDir, { recursive: true, force: true });
 });
 
 describe("tpds CLI binary", () => {
@@ -171,6 +171,47 @@ describe("tpds CLI binary", () => {
     it("exits 1 when file does not exist", () => {
       const result = run("export", "/tmp/tpds-no-such-file.json", "--format", "html");
       expect(result.status).toBe(1);
+    });
+  });
+
+  describe("eval", () => {
+    it("writes a real-world eval bundle for a canonical fixture", () => {
+      const result = run(
+        "eval",
+        simpleFixture,
+        "--output-dir",
+        evalOutDir,
+        "--pdf-title",
+        "Simple Fixture PDF",
+        "--source-url",
+        "https://example.com/simple.pdf",
+        "--evaluator",
+        "Test Runner"
+      );
+      expect(result.status).toBe(0);
+      expect(existsSync(path.join(evalOutDir, "normalized.json"))).toBe(true);
+      expect(existsSync(path.join(evalOutDir, "export.html"))).toBe(true);
+      expect(existsSync(path.join(evalOutDir, "export.md"))).toBe(true);
+      expect(existsSync(path.join(evalOutDir, "export.markdown.json"))).toBe(true);
+      expect(existsSync(path.join(evalOutDir, "chunks.json"))).toBe(true);
+      expect(existsSync(path.join(evalOutDir, "report.md"))).toBe(true);
+
+      const markdownMeta = JSON.parse(
+        readFileSync(path.join(evalOutDir, "export.markdown.json"), "utf8")
+      ) as { fidelity: string; warnings: string[] };
+      expect(markdownMeta.fidelity).toBe("lossless");
+      expect(markdownMeta.warnings).toEqual([]);
+
+      const report = readFileSync(path.join(evalOutDir, "report.md"), "utf8");
+      expect(report).toContain("Simple Fixture PDF");
+      expect(report).toContain("Table detection coverage");
+      expect(report).toContain("Chunk counts:");
+    });
+
+    it("exits 1 when --output-dir is missing", () => {
+      const result = run("eval", simpleFixture);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("--output-dir");
     });
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,12 +1,13 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
+  generateRealWorldEval,
   safeValidateTable,
   validateTable,
   normalizeTable,
   tableToHtml,
   tableToJson,
-  tableToMarkdown,
+  tableToMarkdown
 } from "./index.js";
 
 const USAGE = `Usage: tpds <command> [options]
@@ -21,6 +22,9 @@ Commands:
 
   export <file.json> --format html|markdown|json [--output <file>]
       Export a canonical DocumentTable. Writes to --output or stdout.
+
+  eval <file.json> --output-dir <dir> [--adapter canonical|docling|marker|flat-array]
+      Generate a real-world eval bundle with artifacts and a report template.
 
 Options:
   --help    Show this help message
@@ -40,6 +44,25 @@ const EXPORT_USAGE = `Usage: tpds export <file.json> --format html|markdown|json
 
   --format   Required. One of: html, markdown, json
   --output   Optional. Write to this file instead of stdout.
+`;
+
+const EVAL_USAGE = `Usage: tpds eval <file.json> --output-dir <dir> [options]
+
+  --output-dir            Required. Directory to write the eval bundle into.
+  --adapter               Optional. One of: canonical, docling, marker, flat-array
+  --pdf-title             Optional. Source PDF title for the report.
+  --source-url            Optional. Source PDF URL for the report.
+  --access-date           Optional. Access date to record in the report.
+  --evaluator             Optional. Evaluator name for the report.
+  --extractor             Optional. Upstream extractor name to record.
+  --extractor-command     Optional. Upstream extractor command or revision.
+  --table-id              Optional. Override tableId during adapter normalization.
+  --title                 Optional. Override normalized table title.
+  --caption               Optional. Override normalized table caption.
+  --source-document-id    Optional. Override normalized sourceDocumentId.
+  --page                  Optional. Page number for marker or flat-array inputs.
+  --first-row-is-header   Optional. true/false for flat-array inputs. Defaults to true.
+  --row-group-size        Optional. Row-group chunk size. Defaults to 5.
 `;
 
 type ParsedArgs = {
@@ -62,7 +85,25 @@ function writeStderr(content: string): void {
 function parseArgs(args: string[]): ParsedArgs {
   const positional: string[] = [];
   const flags = new Map<string, string | true>();
-  const VALUE_FLAGS = new Set(["--output", "--format"]);
+  const VALUE_FLAGS = new Set([
+    "--output",
+    "--format",
+    "--output-dir",
+    "--adapter",
+    "--pdf-title",
+    "--source-url",
+    "--access-date",
+    "--evaluator",
+    "--extractor",
+    "--extractor-command",
+    "--table-id",
+    "--title",
+    "--caption",
+    "--source-document-id",
+    "--page",
+    "--first-row-is-header",
+    "--row-group-size"
+  ]);
   let i = 0;
   while (i < args.length) {
     const arg = args[i];
@@ -104,6 +145,22 @@ function writeOutput(content: string, outputPath: string | undefined): void {
     writeStdout(content);
     if (!content.endsWith("\n")) writeStdout("\n");
   }
+}
+
+function parseIntegerFlag(value: string | undefined, name: string): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Error: ${name} must be an integer (got "${value}")`);
+  }
+  return parsed;
+}
+
+function parseBooleanFlag(value: string | undefined, name: string): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (["true", "1", "yes"].includes(value)) return true;
+  if (["false", "0", "no"].includes(value)) return false;
+  throw new Error(`Error: ${name} must be true or false (got "${value}")`);
 }
 
 function main(): number {
@@ -220,6 +277,77 @@ function main(): number {
     }
     writeOutput(output, outputPath);
     return 0;
+  }
+
+  if (command === "eval") {
+    if (isHelp) {
+      writeStdout(EVAL_USAGE);
+      return 0;
+    }
+    const filePath = positional[0];
+    if (!filePath) {
+      writeStderr("Error: eval requires a file path\n");
+      return 1;
+    }
+    const outputDir = flags.get("--output-dir") as string | undefined;
+    if (!outputDir) {
+      writeStderr("Error: eval requires --output-dir\n");
+      return 1;
+    }
+    const adapter = flags.get("--adapter") as string | undefined;
+    if (adapter && !["canonical", "docling", "marker", "flat-array"].includes(adapter)) {
+      writeStderr(
+        `Error: --adapter must be one of: canonical, docling, marker, flat-array (got "${adapter}")\n`
+      );
+      return 1;
+    }
+    let data: unknown;
+    try {
+      data = readJson(filePath);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      writeStderr(`${msg}\n`);
+      return 1;
+    }
+    try {
+      const result = generateRealWorldEval({
+        input: data,
+        inputFile: filePath,
+        outputDir,
+        adapter: adapter as "canonical" | "docling" | "marker" | "flat-array" | undefined,
+        pdfTitle: flags.get("--pdf-title") as string | undefined,
+        sourceUrl: flags.get("--source-url") as string | undefined,
+        accessDate: flags.get("--access-date") as string | undefined,
+        evaluator: flags.get("--evaluator") as string | undefined,
+        extractor: flags.get("--extractor") as string | undefined,
+        extractorCommand: flags.get("--extractor-command") as string | undefined,
+        tableId: flags.get("--table-id") as string | undefined,
+        title: flags.get("--title") as string | undefined,
+        caption: flags.get("--caption") as string | undefined,
+        sourceDocumentId: flags.get("--source-document-id") as string | undefined,
+        page: parseIntegerFlag(flags.get("--page") as string | undefined, "--page"),
+        firstRowIsHeader: parseBooleanFlag(
+          flags.get("--first-row-is-header") as string | undefined,
+          "--first-row-is-header"
+        ),
+        rowGroupSize: parseIntegerFlag(
+          flags.get("--row-group-size") as string | undefined,
+          "--row-group-size"
+        )
+      });
+      writeStdout(`Eval bundle written to ${result.outputDir}\n`);
+      writeStdout(`- ${result.normalizedPath}\n`);
+      writeStdout(`- ${result.htmlPath}\n`);
+      writeStdout(`- ${result.markdownPath}\n`);
+      writeStdout(`- ${result.markdownMetaPath}\n`);
+      writeStdout(`- ${result.chunksPath}\n`);
+      writeStdout(`- ${result.reportPath}\n`);
+      return 0;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      writeStderr(`Eval failed: ${msg}\n`);
+      return 1;
+    }
   }
 
   writeStderr(`Unknown command: "${command}"\n\n`);

--- a/src/eval/generate-real-world-eval.ts
+++ b/src/eval/generate-real-world-eval.ts
@@ -1,0 +1,220 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { basename, resolve } from "node:path";
+import { normalizeFromDocling } from "../adapters/from-docling";
+import { normalizeFromFlatArray } from "../adapters/from-flat-array";
+import { normalizeFromMarker } from "../adapters/from-marker";
+import { buildTableChunks } from "../chunk/build-table-chunks";
+import { tableToHtml } from "../export/to-html";
+import { tableToJson } from "../export/to-json";
+import { tableToMarkdown } from "../export/to-markdown";
+import { documentTableSchema } from "../schema/zod";
+import type { TableChunk, TableChunkType } from "../types/chunk";
+import type { DocumentTable } from "../types/table";
+
+export type EvalAdapter = "canonical" | "docling" | "marker" | "flat-array";
+
+export type GenerateRealWorldEvalOptions = {
+  input: unknown;
+  inputFile?: string;
+  outputDir: string;
+  adapter?: EvalAdapter;
+  pdfTitle?: string;
+  sourceUrl?: string;
+  accessDate?: string;
+  evaluator?: string;
+  extractor?: string;
+  extractorCommand?: string;
+  tableId?: string;
+  title?: string;
+  caption?: string;
+  sourceDocumentId?: string;
+  page?: number;
+  firstRowIsHeader?: boolean;
+  rowGroupSize?: number;
+};
+
+export type GenerateRealWorldEvalResult = {
+  outputDir: string;
+  normalizedPath: string;
+  htmlPath: string;
+  markdownPath: string;
+  markdownMetaPath: string;
+  chunksPath: string;
+  reportPath: string;
+  table: DocumentTable;
+  chunks: TableChunk[];
+};
+
+const today = (): string => new Date().toISOString().slice(0, 10);
+
+const writeTextFile = (filePath: string, content: string): void => {
+  writeFileSync(filePath, content.endsWith("\n") ? content : `${content}\n`, "utf8");
+};
+
+const toJsonFile = (filePath: string, value: unknown): void => {
+  writeTextFile(filePath, JSON.stringify(value, null, 2));
+};
+
+const countChunks = (chunks: TableChunk[], type: TableChunkType): number =>
+  chunks.filter((chunk) => chunk.chunkType === type).length;
+
+const renderReport = (
+  table: DocumentTable,
+  chunks: TableChunk[],
+  options: GenerateRealWorldEvalOptions
+): string => {
+  const markdownResult = tableToMarkdown(table);
+  const displayTitle =
+    options.pdfTitle ?? table.title ?? table.caption ?? table.sourceFileName ?? table.tableId;
+  const inputLabel = options.inputFile ? basename(options.inputFile) : "(not recorded)";
+  const pages = table.pages.join(", ");
+  const fidelityWarnings =
+    table.fidelityWarnings && table.fidelityWarnings.length > 0
+      ? table.fidelityWarnings.map((warning) => `\`${warning}\``).join(", ")
+      : "none";
+  const markdownWarnings =
+    markdownResult.warnings.length > 0
+      ? markdownResult.warnings.map((warning) => `\`${warning}\``).join(", ")
+      : "none";
+
+  return `# TPDS Real-World Eval — ${displayTitle}
+
+## Run metadata
+
+- Source PDF title: ${options.pdfTitle ?? "(fill in if different from normalized title)"}
+- Source URL: ${options.sourceUrl ?? "(fill in)"}
+- Access date: ${options.accessDate ?? today()}
+- Evaluator: ${options.evaluator ?? "(fill in)"}
+- Input file: ${inputLabel}
+- TPDS adapter: \`${options.adapter ?? "canonical"}\`
+- Upstream extractor: ${options.extractor ?? "(fill in)"}
+- Extractor command or revision: ${options.extractorCommand ?? "(fill in)"}
+
+## Generated artifacts
+
+- \`normalized.json\` — canonical TPDS JSON
+- \`export.html\` — HTML review export
+- \`export.md\` — Markdown export
+- \`export.markdown.json\` — Markdown fidelity + warnings
+- \`chunks.json\` — full chunk output
+
+## Auto-observed signals
+
+- Table ID: \`${table.tableId}\`
+- Pages: ${pages || "none"}
+- Row count: ${table.rows.length}
+- Column count: ${table.columns.length}
+- Header groups: ${table.headerGroups?.length ?? 0}
+- Notes count: ${table.notes?.length ?? 0}
+- Footnotes count: ${table.footnotes?.length ?? 0}
+- Table fidelity warnings: ${fidelityWarnings}
+- Markdown fidelity: \`${markdownResult.fidelity}\`
+- Markdown warnings: ${markdownWarnings}
+- Chunk counts: summary=${countChunks(chunks, "summary")}, row=${countChunks(chunks, "row")}, row-group=${countChunks(chunks, "row-group")}, notes=${countChunks(chunks, "notes")}
+
+## Rubric
+
+Use only \`pass\`, \`follow-up\`, or \`fail\` in the Outcome column.
+
+| Dimension | Outcome | Notes |
+|---|---|---|
+| Table detection coverage | \`pass|follow-up|fail\` | |
+| Row/column structure preservation | \`pass|follow-up|fail\` | |
+| Repeated-header handling | \`pass|follow-up|fail\` | |
+| Multi-page merge correctness | \`pass|follow-up|fail\` | |
+| Merged-cell preservation | \`pass|follow-up|fail\` | |
+| Nested-header fidelity | \`pass|follow-up|fail\` | |
+| Notes and footnotes retention | \`pass|follow-up|fail\` | |
+| HTML export usefulness | \`pass|follow-up|fail\` | |
+| Markdown fallback quality | \`pass|follow-up|fail\` | |
+| Chunk usefulness | \`pass|follow-up|fail\` | |
+| Manual cleanup burden | \`pass|follow-up|fail\` | |
+
+## Overall call
+
+- Outcome: \`pass|follow-up|fail\`
+- Summary:
+- Issues opened:
+`;
+};
+
+const normalizeInput = (input: unknown, options: GenerateRealWorldEvalOptions): DocumentTable => {
+  const adapter = options.adapter ?? "canonical";
+
+  if (adapter === "canonical") {
+    return documentTableSchema.parse(input);
+  }
+
+  if (adapter === "docling") {
+    return normalizeFromDocling(input, {
+      tableId: options.tableId,
+      title: options.title,
+      caption: options.caption,
+      sourceDocumentId: options.sourceDocumentId
+    });
+  }
+
+  if (adapter === "marker") {
+    return normalizeFromMarker(input, {
+      tableId: options.tableId,
+      title: options.title,
+      caption: options.caption,
+      sourceDocumentId: options.sourceDocumentId,
+      page: options.page
+    });
+  }
+
+  if (!Array.isArray(input)) {
+    throw new Error('generateRealWorldEval: adapter "flat-array" requires a JSON array of row arrays');
+  }
+  if (input.some((row) => !Array.isArray(row))) {
+    throw new Error(
+      'generateRealWorldEval: adapter "flat-array" requires every top-level item to be a row array'
+    );
+  }
+
+  return normalizeFromFlatArray(input as string[][], {
+    firstRowIsHeader: options.firstRowIsHeader ?? true,
+    tableId: options.tableId,
+    title: options.title,
+    pages: options.page !== undefined ? [options.page] : undefined,
+    standardVersion: undefined
+  });
+};
+
+export const generateRealWorldEval = (
+  options: GenerateRealWorldEvalOptions
+): GenerateRealWorldEvalResult => {
+  const outputDir = resolve(options.outputDir);
+  mkdirSync(outputDir, { recursive: true });
+
+  const table = normalizeInput(options.input, options);
+  const markdownResult = tableToMarkdown(table);
+  const chunks = buildTableChunks(table, { rowGroupSize: options.rowGroupSize ?? 5 });
+
+  const normalizedPath = resolve(outputDir, "normalized.json");
+  const htmlPath = resolve(outputDir, "export.html");
+  const markdownPath = resolve(outputDir, "export.md");
+  const markdownMetaPath = resolve(outputDir, "export.markdown.json");
+  const chunksPath = resolve(outputDir, "chunks.json");
+  const reportPath = resolve(outputDir, "report.md");
+
+  writeTextFile(normalizedPath, tableToJson(table));
+  writeTextFile(htmlPath, tableToHtml(table));
+  writeTextFile(markdownPath, markdownResult.markdown);
+  toJsonFile(markdownMetaPath, markdownResult);
+  toJsonFile(chunksPath, chunks);
+  writeTextFile(reportPath, renderReport(table, chunks, options));
+
+  return {
+    outputDir,
+    normalizedPath,
+    htmlPath,
+    markdownPath,
+    markdownMetaPath,
+    chunksPath,
+    reportPath,
+    table,
+    chunks
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,12 @@ export { buildRowChunks } from "./chunk/build-row-chunks";
 export { buildSummaryChunk } from "./chunk/build-summary-chunk";
 export type { BuildRowGroupChunksOptions } from "./chunk/build-table-chunks";
 export { buildRowGroupChunks, buildTableChunks } from "./chunk/build-table-chunks";
+export type {
+  EvalAdapter,
+  GenerateRealWorldEvalOptions,
+  GenerateRealWorldEvalResult
+} from "./eval/generate-real-world-eval";
+export { generateRealWorldEval } from "./eval/generate-real-world-eval";
 export { tableToHtml } from "./export/to-html";
 export { tableToJson } from "./export/to-json";
 export { tableToMarkdown } from "./export/to-markdown";


### PR DESCRIPTION
## Summary

Adds a repo-native real-world evaluation workflow for TPDS so extracted table JSON can be turned into a saved review bundle from one command.

Closes #93.

## What changed

- added `tpds eval` to the CLI
- added a `generateRealWorldEval` helper and exported it from the package API
- supported artifact generation for normalized JSON, HTML, Markdown, Markdown metadata, chunk output, and a rubric-oriented `report.md`
- documented the intended EPSCA workflow in `docs/real-world-eval.md`
- added CLI coverage for the new command and tightened the CLI test build behavior

## Why

The evaluation note defined what evidence to capture, but the repo did not yet provide a repeatable command to produce that evidence. This change makes the first EPSCA real-world pass concrete and reproducible.

## Validation

- `npm run lint`
- `npm test`
- `npm run build`